### PR TITLE
Add Grunt watch.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -143,6 +143,9 @@ module.exports = (grunt) ->
           port: 9876
           base: '.'
 
+    watch:
+      files: 'src/**/*.coffee'
+      tasks: ['dist']
 
 
   # Dependencies

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "grunt-bump": "~0.0.10",
     "grunt-contrib-coffee": "~0.7",
     "grunt-contrib-clean": "~0.5",
+    "grunt-contrib-watch": "~0.6.1",
     "grunt-mocha-test": "~0.8.0",
     "grunt-mocha-cov": "0.0.7",
     "grunt-blanket-mocha": "git://github.com/philschatz/grunt-blanket-mocha.git#fixes-for-octokit.js",


### PR DESCRIPTION
I would like to run `test` instead of `dist`, but it takes 10s, so just run `dist` which takes only 1s.
