### PR TITLE
Gitignore fixtures and dist/commonjs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-/node_modules
 /bower_components
+/dist/commonjs
+/fixtures
+/node_modules
 /tmp

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+*
+!/index.js
+!/dist/commonjs/*


### PR DESCRIPTION
Fixes #1.

Gitignores:
- fixtures: pretty sure it should be ignored
- dist/commonjs. Please confirm. I imagine it should because only `dist/octokat.js` needs to be Git tracked for bower, while the CommonJS targets NPM Nodejs users.

This requires the addition of a `.npmignore` so that NPM won't use the `.gitignore` which would ignore `dist/commonjs/`. `package.json` is never ignored, so `*` works.

Tested locally with `npm  install -g .` and worked. 
