### PR TITLE
[WIP] Use ES5 Object.defineProperty instead of __defineGetter__.

### DIFF
--- a/src/chainer.coffee
+++ b/src/chainer.coffee
@@ -60,8 +60,10 @@ Chainer = (request, _path, name, contextTree, fn) ->
 
   for name of contextTree or {}
     do (name) ->
-      fn.__defineGetter__ plus.camelize(name), () ->
-        return Chainer(request, "#{_path}/#{name}", name, contextTree[name])
+      Object.defineProperty fn, plus.camelize(name),
+        configurable: true
+        enumerable: true
+        get: () -> return Chainer(request, "#{_path}/#{name}", name, contextTree[name])
 
 
   return fn


### PR DESCRIPTION
`__defineGetter__` is non standard and deprecated: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineGetter

`Object.defineProperty` is ES5 has good browser support: http://kangax.github.io/compat-table/es5/

WIP because there are two failing tests and I'm too lazy to debug right now:

```
1) Gists forks an existing gist:
  Error: timeout of 10000ms exceeded
  at [object Object].<anonymous> (/home/ciro/bak/git/octokat.js/node_modules/mocha/lib/runnable.js:165:14)
  at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)

2) Gists deletes a gist:
  Error: timeout of 10000ms exceeded
  at [object Object].<anonymous> (/home/ciro/bak/git/octokat.js/node_modules/mocha/lib/runnable.js:165:14)
  at Timer.listOnTimeout [as ontimeout] (timers.js:110:1
```
