### PR TITLE
Build JS files so browserify works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /bower_components
-/dist/commonjs
-/fixtures
+/dist/node
+/fixtures*
 /node_modules
 /tmp

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,10 @@
-dist/
+.*
+dist/octokat.js
+src/
 test/
 bower.json
 Gruntfile.coffee
 
 /bower_components
-/fixtures
+/fixtures*
+/foo*

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -108,6 +108,20 @@ module.exports = (grunt) ->
       tasks: ['dist']
 
 
+    # Build the JS files for npm so the library can be used with browserify
+    coffee:
+      compile:
+        files:
+          'dist/node/chainer.js'        : 'src/chainer.coffee'
+          'dist/node/grammar.js'        : 'src/grammar.coffee'
+          'dist/node/helper-base64.js'  : 'src/helper-base64.coffee'
+          'dist/node/helper-promise.js' : 'src/helper-promise.coffee'
+          'dist/node/octokat.js'        : 'src/octokat.coffee'
+          'dist/node/plus.js'           : 'src/plus.coffee'
+          'dist/node/replacer.js'       : 'src/replacer.coffee'
+          'dist/node/request.js'        : 'src/request.coffee'
+
+
   # Dependencies
   # ============
   for name of pkg.dependencies when name.substring(0, 6) is 'grunt-'
@@ -122,7 +136,8 @@ module.exports = (grunt) ->
   grunt.registerTask 'dist', [
     'clean'
     'coffeelint'
-    'browserify'
+    'browserify' # Build single file for browsers
+    'coffee' # Build JS files for npm
   ]
 
   grunt.registerTask 'test', [

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "octokat",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Javascript GitHub client for NodeJS or a browser using promises or callbacks",
   "main": "octokat.js",
   "dependencies": {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "octokat",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Javascript GitHub client for NodeJS or a browser using promises or callbacks",
   "main": "octokat.js",
   "dependencies": {

--- a/dist/octokat.js
+++ b/dist/octokat.js
@@ -766,10 +766,8 @@ ajax = function(options, cb) {
         }
       }
       if (xhr.status >= 200 && xhr.status < 300 || xhr.status === 304 || xhr.status === 302) {
-        console.log(xhr.status, ' ', options.type, options.url);
         return cb(null, xhr);
       } else {
-        console.log(xhr.status, 'X', options.type, options.url);
         return cb(xhr);
       }
     }

--- a/index.js
+++ b/index.js
@@ -1,2 +1,1 @@
-require('coffee-script/register');
-module.exports = require('./src/octokat');
+module.exports = require('./dist/node/octokat');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octokat",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Javascript GitHub client for NodeJS or a browser using promises or callbacks",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octokat",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Javascript GitHub client for NodeJS or a browser using promises or callbacks",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Javascript GitHub client for NodeJS or a browser using promises or callbacks",
   "main": "index.js",
   "scripts": {
-    "prepublish": "bower install",
     "test": "VCR_MODE=cache grunt test --verbose",
     "dist": "grunt dist --verbose",
     "update": "bower update",
@@ -15,7 +14,6 @@
     }
   },
   "dependencies": {
-    "coffee-script": "^1.8.0",
     "es6-promise": "0.1.2",
     "xmlhttprequest": "~1.6.0"
   },
@@ -28,6 +26,7 @@
     "grunt-bump": "~0.0.10",
     "grunt-coffeelint": "~0.0.7",
     "grunt-contrib-clean": "~0.5",
+    "grunt-contrib-coffee": "^0.12.0",
     "grunt-contrib-connect": "~0.7.1",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-mocha-phantomjs": "~0.5.0",


### PR DESCRIPTION
This should fix #10 instead of having a postinstall hook that relies on `coffee` as in #19