### PR TITLE
add preview apis (license, star, authorizations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,9 @@ octo.repos('philschatz', 'octokat.js').commits.fetch()
 
 ## Preview new APIs
 
-To use the APIs available for preview just add a `acceptHeader` when instantiating Octokat.
+Octokat will send the Preview Accept header by default for several Preview APIs.
+
+If you want to change this behavior you can force an `acceptHeader` when instantiating Octokat.
 
 For example:
 

--- a/src/request.coffee
+++ b/src/request.coffee
@@ -1,4 +1,5 @@
 base64encode = require './helper-base64'
+{DEFAULT_HEADER} = require './grammar'
 
 # Request Function
 # ===============================
@@ -56,7 +57,6 @@ Request = (clientOptions={}) ->
   clientOptions.rootURL ?= 'https://api.github.com'
   clientOptions.useETags ?= true
   clientOptions.usePostInsteadOfPatch ?= false
-  clientOptions.acceptHeader ?= 'application/vnd.github.v3+json'
 
   # These are updated whenever a request is made
   _listeners = []
@@ -89,7 +89,8 @@ Request = (clientOptions={}) ->
     mimeType = 'text/plain; charset=x-user-defined' if options.isBase64
 
     headers = {
-      'Accept': clientOptions.acceptHeader
+      # Use the preview API header if one of the routes match the preview APIs
+      'Accept': clientOptions.acceptHeader or DEFAULT_HEADER(path)
     }
     headers['Accept'] = 'application/vnd.github.raw' if options.raw
 


### PR DESCRIPTION
sends the preview API header when the route is called

Adds support for:

- Licenses
- OAuth Authorizations
- `starred_at`