### PR TITLE
provide fooUrl for non-templated url fields

### DIFF
--- a/dist/octokat.js
+++ b/dist/octokat.js
@@ -730,6 +730,9 @@ Replacer = (function() {
         return function() {
           var args, cb, contentType, data, i, m, match, param, ref1, url;
           cb = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
+          if (!(/\{/.test(value) || /_page_url$/.test(key))) {
+            console.warn('Deprecation warning: Use the .fooUrl field instead of calling the method');
+          }
           url = value;
           i = 0;
           while (m = /(\{[^\}]+\})/.exec(url)) {
@@ -766,7 +769,10 @@ Replacer = (function() {
       fn = toPromise(fn);
       fn.url = value;
       newKey = key.substring(0, key.length - '_url'.length);
-      return acc[plus.camelize(newKey)] = fn;
+      acc[plus.camelize(newKey)] = fn;
+      if (!/\{/.test(value)) {
+        return acc[plus.camelize(key)] = value;
+      }
     } else if (/_at$/.test(key)) {
       return acc[plus.camelize(key)] = new Date(value);
     } else {
@@ -976,7 +982,7 @@ Request = function(clientOptions) {
           }
           if (method === 'GET' && options.isBase64) {
             converted = '';
-            for (i = l = 0, ref2 = data.length; 0 <= ref2 ? l <= ref2 : l >= ref2; i = 0 <= ref2 ? ++l : --l) {
+            for (i = l = 0, ref2 = data.length; 0 <= ref2 ? l < ref2 : l > ref2; i = 0 <= ref2 ? ++l : --l) {
               converted += String.fromCharCode(data.charCodeAt(i) & 0xff);
             }
             data = converted;

--- a/src/replacer.coffee
+++ b/src/replacer.coffee
@@ -62,6 +62,11 @@ class Replacer
   _replaceKeyValue: (acc, key, value) ->
     if /_url$/.test(key)
       fn = (cb, args...) =>
+        # Deprecate calling this function when the URL does not contain
+        # any template args.
+        unless /\{/.test(value) or /_page_url$/.test(key)
+          console.warn('Deprecation warning: Use the .fooUrl field instead of calling the method')
+
         # url can contain {name} or {/name} in the URL.
         # for every arg passed in, replace {...} with that arg
         # and remove the rest (they may or may not be optional)
@@ -102,6 +107,10 @@ class Replacer
       fn.url = value
       newKey = key.substring(0, key.length-'_url'.length)
       acc[plus.camelize(newKey)] = fn
+      # add a camelCase URL field for retrieving non-templated URLs
+      # like `avatarUrl` and `htmlUrl`
+      unless /\{/.test(value)
+        acc[plus.camelize(key)] = value
 
     else if /_at$/.test(key)
       acc[plus.camelize(key)] = new Date(value)

--- a/test/simple.spec.coffee
+++ b/test/simple.spec.coffee
@@ -216,6 +216,11 @@ define ['chai', 'cs!./test-config'], ({assert, expect}, {client, USERNAME, TOKEN
       itIsArray(REPO, 'stargazers.fetch')
       itIsArray(REPO, 'forks.fetch')
 
+      it "camelCases URL fields that are not templated (ie #{REPO}.htmlUrl)", (done) ->
+        STATE[REPO].fetch().then (repo) ->
+          expect(repo.htmlUrl).to.be.a('string')
+          done()
+
       describe "#{REPO}.issues...", () ->
         itIsArray(REPO, 'issues.fetch')
         itIsArray(REPO, 'issues.events.fetch')
@@ -311,6 +316,11 @@ define ['chai', 'cs!./test-config'], ({assert, expect}, {client, USERNAME, TOKEN
       itIsArray(USER, 'receivedEvents.fetch')
       itIsArray(USER, 'starred.fetch')
 
+      it "camelCases URL fields that are not templated (ie #{USER}.avatarUrl)", (done) ->
+        STATE[USER].fetch().then (repo) ->
+          expect(repo.htmlUrl).to.be.a('string')
+          expect(repo.avatarUrl).to.be.a('string')
+          done()
 
     describe "#{ORG} = #{GH}.orgs(ORG_NAME)", () ->
 
@@ -406,9 +416,10 @@ define ['chai', 'cs!./test-config'], ({assert, expect}, {client, USERNAME, TOKEN
         # itIsOk(REPO, 'issues.comments.update', 43218269, {body: 'Test comment updated'})
         itIsOk(REPO, 'issues.comments', 43218269, 'fetch')
 
-        it 'comment.issue()', (done) ->
-          trapFail STATE[REPO].issues.comments(43218269).fetch()
-          .then (comment) ->
-            comment.issue()
-            .then (v) ->
-              done()
+        # Deprecated. Now provides only `issueUrl`
+        # it 'comment.issue()', (done) ->
+        #   trapFail STATE[REPO].issues.comments(43218269).fetch()
+        #   .then (comment) ->
+        #     comment.issue()
+        #     .then (v) ->
+        #       done()


### PR DESCRIPTION
fixes #42 . Things like the following are now allowed:

```coffee
client.users('philschatz').fetch()
.then (user) ->
  console.log(user.avatarUrl)
```