### PR TITLE
provide .getPath() to provide the constructed path

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The basic structure of the *verb method* is:
 - `.foos.contains(id)` tests membership in a list (yields true/false)
 - `.foos(id).read()` is similar to `.fetch()` but yields the text contents without the wrapper JSON
 - `.foos(id).readBinary()` is similar to `.read()` but yields binary data
+- `.foos.getPath()` is *synchronous* and returns the constructed path
 
 
 # Examples

--- a/dist/octokat.js
+++ b/dist/octokat.js
@@ -101,6 +101,9 @@ Chainer = function(request, _path, name, contextTree, fn) {
       verbFunc = verbs[verbName];
       fn[verbName] = toPromise(verbFunc);
     }
+    fn.getPath = function() {
+      return _path;
+    };
   }
   if (typeof fn === 'function' || typeof fn === 'object') {
     fn1 = function(name) {

--- a/src/chainer.coffee
+++ b/src/chainer.coffee
@@ -57,6 +57,8 @@ Chainer = (request, _path, name, contextTree, fn) ->
     for verbName, verbFunc of verbs
       fn[verbName] = toPromise(verbFunc)
 
+    # Provide a method for getting the URL path of a constructed request
+    fn.getPath = -> _path
 
   if typeof fn is 'function' or typeof fn is 'object'
     for name of contextTree or {}

--- a/test/simple.spec.coffee
+++ b/test/simple.spec.coffee
@@ -145,6 +145,10 @@ define ['chai', 'cs!./test-config'], ({assert, expect}, {client, USERNAME, TOKEN
         expect(ret.fetch).to.not.be.null
         expect(ret.issues).to.not.be.null
 
+      it 'supports .getPath as a verb', () ->
+        expect(client.repos(REPO_USER, REPO_NAME).getPath()).to.be.a('string')
+        expect(client.repos(REPO_USER, REPO_NAME).getPath()).to.equal("/repos/#{REPO_USER}/#{REPO_NAME}")
+
     describe 'Miscellaneous APIs', () ->
       itIsOk(GH, 'zen.read')
       itIsOk(GH, 'octocat.read')


### PR DESCRIPTION
**Note:** does not include the hostname

Examples:

```coffee
octo.repos('philschatz', 'octokat.js').getPath()
# returns `/repos/philschatz/octokat.js`
```