### PR TITLE
support comparing tags and branches instead of just sha

### DIFF
--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -93,7 +93,7 @@ URL_VALIDATOR = /// ^
           readme
         | tarball (/[^/]+)?
         | zipball (/[^/]+)?
-        | compare / [a-f0-9:]{40} \.{3} [a-f0-9:]{40}
+        | compare / ([^\.{3}]+) \.{3} ([^\.{3}]+)    # Can compare a tag, part of a commit sha, branch (with `/`)
         | deployments (/[0-9]+)?
         | deployments / [0-9]+ / statuses (/[0-9]+)?
         | hooks


### PR DESCRIPTION
Currently the grammar allows comparing 2 commits but gives a warning when trying to compare a branch/tag.