### PR TITLE
include the reset time in rate limit data

### DIFF
--- a/dist/octokat.js
+++ b/dist/octokat.js
@@ -1009,11 +1009,9 @@ Request = function(clientOptions) {
           } else {
             return cb(null, jqXHR.responseText, status, jqXHR);
           }
-        } else if (jqXHR.status === 204 && options.isBoolean) {
-
         } else if (jqXHR.status === 302) {
           return cb(null, jqXHR.getResponseHeader('Location'));
-        } else {
+        } else if (!(jqXHR.status === 204 && options.isBoolean)) {
           if (jqXHR.responseText && ajaxConfig.dataType === 'json') {
             data = JSON.parse(jqXHR.responseText);
             links = jqXHR.getResponseHeader('Link');

--- a/dist/octokat.js
+++ b/dist/octokat.js
@@ -888,9 +888,7 @@ Request = function(clientOptions) {
   if (clientOptions.usePostInsteadOfPatch == null) {
     clientOptions.usePostInsteadOfPatch = false;
   }
-  emitter = clientOptions.emitter || {
-    emit: function() {}
-  };
+  emitter = clientOptions.emitter;
   _cachedETags = {};
   cacheHandler = clientOptions.cacheHandler || {
     get: function(method, path) {
@@ -981,12 +979,28 @@ Request = function(clientOptions) {
         })(this)
       };
     }
+    if (emitter != null) {
+      emitter.emit('start', method, path, data, options);
+    }
     return ajax(ajaxConfig, function(err, val) {
-      var converted, discard, eTag, eTagResponse, href, i, j, jqXHR, json, k, len, links, part, rateLimit, rateLimitRemaining, ref, ref1, ref2, rel;
+      var converted, discard, eTag, eTagResponse, emitterRate, href, i, j, jqXHR, json, k, len, links, part, rateLimit, rateLimitRemaining, rateLimitReset, ref, ref1, ref2, rel;
       jqXHR = err || val;
-      rateLimit = parseFloat(jqXHR.getResponseHeader('X-RateLimit-Limit'));
-      rateLimitRemaining = parseFloat(jqXHR.getResponseHeader('X-RateLimit-Remaining'));
-      emitter.emit('request', rateLimitRemaining, rateLimit, method, path, data, options);
+      if (emitter) {
+        rateLimit = parseFloat(jqXHR.getResponseHeader('X-RateLimit-Limit'));
+        rateLimitRemaining = parseFloat(jqXHR.getResponseHeader('X-RateLimit-Remaining'));
+        rateLimitReset = parseFloat(jqXHR.getResponseHeader('X-RateLimit-Reset'));
+        emitterRate = {
+          rate: {
+            remaining: rateLimitRemaining,
+            limit: rateLimit,
+            reset: rateLimitReset
+          }
+        };
+        if (jqXHR.getResponseHeader('X-OAuth-Scopes')) {
+          emitterRate.scopes = jqXHR.getResponseHeader('X-OAuth-Scopes').split(', ');
+        }
+        emitter.emit('request', emitterRate, method, path, data, options, jqXHR.status);
+      }
       if (!err) {
         if (jqXHR.status === 304) {
           if (clientOptions.useETags && cacheHandler.get(method, path)) {

--- a/src/request.coffee
+++ b/src/request.coffee
@@ -180,15 +180,12 @@ Request = (clientOptions={}) ->
           else
             cb(null, jqXHR.responseText, status, jqXHR)
 
-        # If it was a boolean question and the server responded with 204
-        # return true.
-        else if jqXHR.status is 204 and options.isBoolean
-          # cb(null, true, status, jqXHR)
         # Respond with the redirect URL (for archive links)
         # TODO: implement a `followRedirects` flag
         else if jqXHR.status is 302
           cb(null, jqXHR.getResponseHeader('Location'))
-        else
+        # If it was a boolean question and the server responded with 204 ignore.
+        else unless jqXHR.status is 204 and options.isBoolean
           if jqXHR.responseText and ajaxConfig.dataType is 'json'
             data = JSON.parse(jqXHR.responseText)
 

--- a/src/request.coffee
+++ b/src/request.coffee
@@ -163,6 +163,9 @@ Request = (clientOptions={}) ->
             remaining: rateLimitRemaining
             limit: rateLimit
             reset: rateLimitReset # Reset time is in seconds, not milliseconds
+
+        if jqXHR.getResponseHeader('X-OAuth-Scopes')
+          emitterRate.scopes = jqXHR.getResponseHeader('X-OAuth-Scopes').split(', ')
         emitter.emit('request', emitterRate, method, path, data, options, jqXHR.status)
 
       unless err

--- a/src/request.coffee
+++ b/src/request.coffee
@@ -58,9 +58,8 @@ Request = (clientOptions={}) ->
   clientOptions.useETags ?= true
   clientOptions.usePostInsteadOfPatch ?= false
 
-  # These are updated whenever a request is made
-  emitter = clientOptions.emitter or
-    emit: ->
+  # These are updated whenever a request is made (optional)
+  emitter = clientOptions.emitter
 
   # Cached responses are stored in this object keyed by `path`
   _cachedETags = {}
@@ -147,14 +146,24 @@ Request = (clientOptions={}) ->
         204: () => cb(null, true)
         404: () => cb(null, false)
 
+    emitter?.emit('start', method, path, data, options)
+
     ajax ajaxConfig, (err, val) ->
 
       jqXHR = err or val
       # Fire listeners when the request completes or fails
-      rateLimit = parseFloat(jqXHR.getResponseHeader 'X-RateLimit-Limit')
-      rateLimitRemaining = parseFloat(jqXHR.getResponseHeader 'X-RateLimit-Remaining')
 
-      emitter.emit('request', rateLimitRemaining, rateLimit, method, path, data, options)
+      if emitter
+        rateLimit = parseFloat(jqXHR.getResponseHeader('X-RateLimit-Limit'))
+        rateLimitRemaining = parseFloat(jqXHR.getResponseHeader('X-RateLimit-Remaining'))
+        rateLimitReset = parseFloat(jqXHR.getResponseHeader('X-RateLimit-Reset'))
+
+        emitterRate =
+          rate:   # to match the JSON format of `GET /rate_limit`
+            remaining: rateLimitRemaining
+            limit: rateLimit
+            reset: rateLimitReset # Reset time is in seconds, not milliseconds
+        emitter.emit('request', emitterRate, method, path, data, options, jqXHR.status)
 
       unless err
         # Return the result and Base64 encode it if `options.isBase64` flag is set.


### PR DESCRIPTION
The event that is fired on every request includes some but not all the rate limit headers. This adds the remaining one, `reset` (When the API's rate limit will reset).

Currently, an additional request to `/rate_limit` is required to get that information.


TODO:

- [x] maybe include other response headers as well like the `X-OAuth-Scopes` header