### PR TITLE
add option to disable modifying the API response JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ Otherwise, you can include a Promise polyfill like [jakearchibald/es6-promise](h
 ## Hypermedia
 
 GitHub provides URL patterns in its JSON responses. These are automatically converted into methods.
+You can disable this by setting `disableHypermedia: true` in the options when creating a `new Octokat(...)`.
+
 For example:
 
 ```coffee

--- a/dist/octokat.js
+++ b/dist/octokat.js
@@ -126,7 +126,7 @@ module.exports = Chainer;
 },{"./grammar":2,"./helper-promise":4,"./plus":6}],2:[function(require,module,exports){
 var DEFAULT_HEADER, OBJECT_MATCHER, PREVIEW_HEADERS, TREE_OPTIONS, URL_VALIDATOR;
 
-URL_VALIDATOR = /^(https?:\/\/[^\/]+)?(\/api\/v3)?\/(zen|octocat|users|issues|gists|emojis|markdown|meta|rate_limit|feeds|events|notifications|notifications\/threads(\/[^\/]+)|notifications\/threads(\/[^\/]+)\/subscription|gitignore\/templates(\/[^\/]+)?|user|user\/(repos|orgs|followers|following(\/[^\/]+)?|emails(\/[^\/]+)?|issues|starred|starred(\/[^\/]+){2}|teams)|orgs\/[^\/]+|orgs\/[^\/]+\/(repos|issues|members|events|teams)|teams\/[^\/]+|teams\/[^\/]+\/(members(\/[^\/]+)?|memberships\/[^\/]+|repos|repos(\/[^\/]+){2})|users\/[^\/]+|users\/[^\/]+\/(repos|orgs|gists|followers|following(\/[^\/]+){0,2}|keys|starred|received_events(\/public)?|events(\/public)?|events\/orgs\/[^\/]+)|search\/(repositories|issues|users|code)|gists\/(public|starred|([a-f0-9]{20}|[0-9]+)|([a-f0-9]{20}|[0-9]+)\/forks|([a-f0-9]{20}|[0-9]+)\/comments(\/[0-9]+)?|([a-f0-9]{20}|[0-9]+)\/star)|repos(\/[^\/]+){2}|repos(\/[^\/]+){2}\/(readme|tarball(\/[^\/]+)?|zipball(\/[^\/]+)?|compare\/[a-f0-9:]{40}\.{3}[a-f0-9:]{40}|deployments(\/[0-9]+)?|deployments\/[0-9]+\/statuses(\/[0-9]+)?|hooks|hooks\/[^\/]+|hooks\/[^\/]+\/tests|assignees|languages|teams|tags|branches(\/[^\/]+){0,2}|contributors|subscribers|subscription|stargazers|comments(\/[0-9]+)?|downloads(\/[0-9]+)?|forks|milestones|milestones\/[0-9]+|milestones\/[0-9]+\/labels|labels(\/[^\/]+)?|releases|releases\/([0-9]+)|releases\/([0-9]+)\/assets|releases\/latest|releases\/tags\/([^\/]+)|releases\/assets\/([0-9]+)|events|notifications|merges|statuses\/[a-f0-9]{40}|pages|pages\/builds|pages\/builds\/latest|commits|commits\/[a-f0-9]{40}|commits\/[a-f0-9]{40}\/(comments|status|statuses)?|contents\/|contents(\/[^\/]+)*|collaborators(\/[^\/]+)?|(issues|pulls)|(issues|pulls)\/(events|events\/[0-9]+|comments(\/[0-9]+)?|[0-9]+|[0-9]+\/events|[0-9]+\/comments|[0-9]+\/labels(\/[^\/]+)?)|pulls\/[0-9]+\/(files|commits)|git\/(refs|refs\/heads(\/[^\/]+)?|trees(\/[^\/]+)?|blobs(\/[a-f0-9]{40}$)?|commits(\/[a-f0-9]{40}$)?)|stats\/(contributors|commit_activity|code_frequency|participation|punch_card))|licenses|licenses\/([^\/]+)|authorizations|authorizations\/((\d+)|clients\/([^\/]{20})|clients\/([^\/]{20})\/([^\/]+))|applications\/([^\/]{20})\/tokens|applications\/([^\/]{20})\/tokens\/([^\/]+)|enterprise\/(settings\/license|stats\/(issues|hooks|milestones|orgs|comments|pages|users|gists|pulls|repos|all))|staff\/indexing_jobs|users\/[^\/]+\/(site_admin|suspended)|setup\/api\/(start|upgrade|configcheck|configure|settings(authorized-keys)?|maintenance))$/;
+URL_VALIDATOR = /^(https?:\/\/[^\/]+)?(\/api\/v3)?\/(zen|octocat|users|issues|gists|emojis|markdown|meta|rate_limit|feeds|events|notifications|notifications\/threads(\/[^\/]+)|notifications\/threads(\/[^\/]+)\/subscription|gitignore\/templates(\/[^\/]+)?|user|user\/(repos|orgs|followers|following(\/[^\/]+)?|emails(\/[^\/]+)?|issues|starred|starred(\/[^\/]+){2}|teams)|orgs\/[^\/]+|orgs\/[^\/]+\/(repos|issues|members|events|teams)|teams\/[^\/]+|teams\/[^\/]+\/(members(\/[^\/]+)?|memberships\/[^\/]+|repos|repos(\/[^\/]+){2})|users\/[^\/]+|users\/[^\/]+\/(repos|orgs|gists|followers|following(\/[^\/]+){0,2}|keys|starred|received_events(\/public)?|events(\/public)?|events\/orgs\/[^\/]+)|search\/(repositories|issues|users|code)|gists\/(public|starred|([a-f0-9]{20}|[0-9]+)|([a-f0-9]{20}|[0-9]+)\/forks|([a-f0-9]{20}|[0-9]+)\/comments(\/[0-9]+)?|([a-f0-9]{20}|[0-9]+)\/star)|repos(\/[^\/]+){2}|repos(\/[^\/]+){2}\/(readme|tarball(\/[^\/]+)?|zipball(\/[^\/]+)?|compare\/[a-f0-9:]{40}\.{3}[a-f0-9:]{40}|deployments(\/[0-9]+)?|deployments\/[0-9]+\/statuses(\/[0-9]+)?|hooks|hooks\/[^\/]+|hooks\/[^\/]+\/tests|assignees|languages|teams|tags|branches(\/[^\/]+){0,2}|contributors|subscribers|subscription|stargazers|comments(\/[0-9]+)?|downloads(\/[0-9]+)?|forks|milestones|milestones\/[0-9]+|milestones\/[0-9]+\/labels|labels(\/[^\/]+)?|releases|releases\/([0-9]+)|releases\/([0-9]+)\/assets|releases\/latest|releases\/tags\/([^\/]+)|releases\/assets\/([0-9]+)|events|notifications|merges|statuses\/[a-f0-9]{40}|pages|pages\/builds|pages\/builds\/latest|commits|commits\/[a-f0-9]{40}|commits\/[a-f0-9]{40}\/(comments|status|statuses)?|contents\/|contents(\/[^\/]+)*|collaborators(\/[^\/]+)?|(issues|pulls)|(issues|pulls)\/(events|events\/[0-9]+|comments(\/[0-9]+)?|[0-9]+|[0-9]+\/events|[0-9]+\/comments|[0-9]+\/labels(\/[^\/]+)?)|pulls\/[0-9]+\/(files|commits)|git\/(refs|refs\/(.+|heads(\/[^\/]+)?|tags(\/[^\/]+)?)|trees(\/[^\/]+)?|blobs(\/[a-f0-9]{40}$)?|commits(\/[a-f0-9]{40}$)?)|stats\/(contributors|commit_activity|code_frequency|participation|punch_card))|licenses|licenses\/([^\/]+)|authorizations|authorizations\/((\d+)|clients\/([^\/]{20})|clients\/([^\/]{20})\/([^\/]+))|applications\/([^\/]{20})\/tokens|applications\/([^\/]{20})\/tokens\/([^\/]+)|enterprise\/(settings\/license|stats\/(issues|hooks|milestones|orgs|comments|pages|users|gists|pulls|repos|all))|staff\/indexing_jobs|users\/[^\/]+\/(site_admin|suspended)|setup\/api\/(start|upgrade|configcheck|configure|settings(authorized-keys)?|maintenance))$/;
 
 TREE_OPTIONS = {
   'zen': false,
@@ -262,7 +262,8 @@ TREE_OPTIONS = {
     },
     'git': {
       'refs': {
-        'heads': false
+        'heads': false,
+        'tags': false
       },
       'trees': false,
       'blobs': false,
@@ -542,11 +543,28 @@ reChainChildren = function(request, url, obj) {
 };
 
 Octokat = function(clientOptions) {
-  var _request, obj, path, request;
+  var _request, disableHypermedia, obj, parse, request;
   if (clientOptions == null) {
     clientOptions = {};
   }
+  disableHypermedia = clientOptions.disableHypermedia;
+  if (disableHypermedia == null) {
+    disableHypermedia = false;
+  }
   _request = Request(clientOptions);
+  parse = function(obj, path, request) {
+    var replacer, url;
+    url = obj.url || path;
+    if (url) {
+      replacer = new Replacer(request);
+      obj = replacer.replace(obj);
+      Chainer(request, url, true, {}, obj);
+      reChainChildren(request, url, obj);
+    } else {
+      Chainer(request, '', null, TREE_OPTIONS, obj);
+    }
+    return obj;
+  };
   request = function(method, path, data, options, cb) {
     var ref1, replacer;
     if (options == null) {
@@ -561,34 +579,26 @@ Octokat = function(clientOptions) {
       data = replacer.uncamelize(data);
     }
     return _request(method, path, data, options, function(err, val) {
-      var obj, url;
+      var obj;
       if (err) {
         return cb(err);
       }
       if (options.raw) {
         return cb(null, val);
       }
-      obj = replacer.replace(val);
-      url = obj.url || path;
-      reChainChildren(request, url, obj);
-      return cb(null, obj);
+      if (!disableHypermedia) {
+        obj = parse(val, path, request);
+        return cb(null, obj);
+      } else {
+        return cb(null, val);
+      }
     });
   };
-  path = '';
   obj = {};
-  Chainer(request, path, null, TREE_OPTIONS, obj);
+  Chainer(request, '', null, TREE_OPTIONS, obj);
   obj.me = obj.user;
   obj.parse = function(jsonObj) {
-    var replacer;
-    if (jsonObj.url) {
-      replacer = new Replacer(request);
-      jsonObj = replacer.replace(jsonObj);
-      Chainer(request, jsonObj.url, true, {}, jsonObj);
-      reChainChildren(request, jsonObj.url, jsonObj);
-    } else {
-      Chainer(request, '', null, TREE_OPTIONS, jsonObj);
-    }
-    return jsonObj;
+    return parse(jsonObj, '', request);
   };
   obj.status = toPromise(function(cb) {
     return request('GET', 'https://status.github.com/api/status.json', null, null, cb);

--- a/test/simple.spec.coffee
+++ b/test/simple.spec.coffee
@@ -1,5 +1,5 @@
 define = window?.define or (deps, cb) -> cb((require(dep.replace('cs!./', './')) for dep in deps)...)
-define ['chai', 'cs!./test-config'], ({assert, expect}, {client, USERNAME, TOKEN, ORG_NAME, REPO_USER, REPO_NAME, REPO_HOMEPAGE, OTHER_HOMEPAGE, OTHER_USERNAME, DEFAULT_BRANCH, LONG_TIMEOUT, SHORT_TIMEOUT}) ->
+define ['chai', 'cs!./test-config'], ({assert, expect}, {Octokat, client, USERNAME, TOKEN, ORG_NAME, REPO_USER, REPO_NAME, REPO_HOMEPAGE, OTHER_HOMEPAGE, OTHER_USERNAME, DEFAULT_BRANCH, LONG_TIMEOUT, SHORT_TIMEOUT}) ->
 
   # NodeJS does not have a btoa
   btoa = @btoa or (str) ->
@@ -453,3 +453,15 @@ define ['chai', 'cs!./test-config'], ({assert, expect}, {client, USERNAME, TOKEN
         #     comment.issue()
         #     .then (v) ->
         #       done()
+
+  describe 'Allows disabling hypermedia conversion', () ->
+    it.only 'returns a simple JSON object when fetching a repository', (done) ->
+      client = new Octokat({token: TOKEN, disableHypermedia: true})
+      client.repos(REPO_USER, REPO_NAME).fetch()
+      .then (repo) ->
+        expect(repo.full_name).to.not.be.null
+        expect(repo.html_url).to.not.be.null
+        expect(repo.created_at).to.be.a('string')
+        # Serializing the object as JSON should work
+        JSON.stringify(repo)
+        done()

--- a/test/test-config.coffee
+++ b/test/test-config.coffee
@@ -16,6 +16,7 @@ define (require) ->
     LONG_TIMEOUT: 10 * 1000 # 10 seconds
     SHORT_TIMEOUT: 5 * 1000 # 5 seconds
 
+  config.Octokat = Octokat
   config.client = new Octokat {token:config.TOKEN}
   config.test_repo = "#{config.REPO_USER}/#{config.REPO_NAME}"
   config.test_github_login = config.USERNAME


### PR DESCRIPTION
This adds an additional config option: `octo = new Octokat({disableHypermedia: true})`

Normally the response from GitHub is modified to do the following:

- convert underscore_values to camelCase
- convert strings to `Date` objects
- convert hypermedia `*_url` to methods that can be called

Sometimes the additional processing is overkill and just a simple JSON response is all that is needed.