### PR TITLE
paged results yield Object instead of array

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,14 +343,17 @@ octo.repos('philschatz', 'octokat.js').fetch()
 ## Paged Results
 
 If a `.fetch()` returns paged results then `nextPage()`, `previousPage()`, `firstPage()`
-and `lastPage()` are added to the returned Object. For example:
+and `lastPage()` are added to the returned Object and the page of results is in `.items:`. For example:
 
 ```coffee
 octo.repos('philschatz', 'octokat.js').commits.fetch()
-.then (someCommits) ->
-  someCommits.nextPage()
-  .then (moreCommits) ->
-    console.log('2nd page of results', moreCommits)
+.then (results) ->
+  console.log(results)
+  # The structure of `results` is:
+  # {items: [...], nextPage: fn, lastPage: fn}
+  results.nextPage()
+  .then (moreResults) ->
+    console.log('2nd page of results', moreResults.items)
 ```
 
 ## Preview new APIs

--- a/dist/octokat.js
+++ b/dist/octokat.js
@@ -552,13 +552,18 @@ Octokat = function(clientOptions) {
     disableHypermedia = false;
   }
   _request = Request(clientOptions);
-  parse = function(obj, path, request) {
+  parse = function(obj, path, request, isChainRoot) {
     var replacer, url;
+    if (isChainRoot == null) {
+      isChainRoot = false;
+    }
     url = obj.url || path;
     if (url) {
       replacer = new Replacer(request);
       obj = replacer.replace(obj);
-      Chainer(request, url, true, {}, obj);
+      if (isChainRoot) {
+        Chainer(request, url, true, {}, obj);
+      }
       reChainChildren(request, url, obj);
     } else {
       Chainer(request, '', null, TREE_OPTIONS, obj);
@@ -587,7 +592,7 @@ Octokat = function(clientOptions) {
         return cb(null, val);
       }
       if (!disableHypermedia) {
-        obj = parse(val, path, request);
+        obj = parse(val, path, request, false);
         return cb(null, obj);
       } else {
         return cb(null, val);
@@ -1031,7 +1036,7 @@ Request = function(clientOptions) {
           if (jqXHR.responseText && ajaxConfig.dataType === 'json') {
             data = JSON.parse(jqXHR.responseText);
             links = jqXHR.getResponseHeader('Link');
-            if (links) {
+            if (Array.isArray(data)) {
               data = {
                 items: data
               };

--- a/dist/octokat.js
+++ b/dist/octokat.js
@@ -1031,11 +1031,16 @@ Request = function(clientOptions) {
           if (jqXHR.responseText && ajaxConfig.dataType === 'json') {
             data = JSON.parse(jqXHR.responseText);
             links = jqXHR.getResponseHeader('Link');
-            ref = (links != null ? links.split(',') : void 0) || [];
-            for (j = 0, len = ref.length; j < len; j++) {
-              part = ref[j];
-              ref1 = part.match(/<([^>]+)>;\ rel="([^"]+)"/), discard = ref1[0], href = ref1[1], rel = ref1[2];
-              data[rel + "_page_url"] = href;
+            if (links) {
+              data = {
+                items: data
+              };
+              ref = (links != null ? links.split(',') : void 0) || [];
+              for (j = 0, len = ref.length; j < len; j++) {
+                part = ref[j];
+                ref1 = part.match(/<([^>]+)>;\ rel="([^"]+)"/), discard = ref1[0], href = ref1[1], rel = ref1[2];
+                data[rel + "_page_url"] = href;
+              }
             }
           } else {
             data = jqXHR.responseText;

--- a/src/octokat.coffee
+++ b/src/octokat.coffee
@@ -25,12 +25,13 @@ Octokat = (clientOptions={}) ->
   # For each request, convert the JSON into Objects
   _request = Request(clientOptions)
 
-  parse = (obj, path, request) ->
+  parse = (obj, path, request, isChainRoot=false) ->
     url = obj.url or path
     if url
       replacer = new Replacer(request)
       obj = replacer.replace(obj)
-      Chainer(request, url, true, {}, obj)
+      if isChainRoot
+        Chainer(request, url, true, {}, obj)
       reChainChildren(request, url, obj)
     else
       Chainer(request, '', null, TREE_OPTIONS, obj)
@@ -51,7 +52,7 @@ Octokat = (clientOptions={}) ->
       return cb(null, val) if options.raw
 
       unless disableHypermedia
-        obj = parse(val, path, request)
+        obj = parse(val, path, request, false) # false == isChainRoot
         return cb(null, obj)
       else
         return cb(null, val)

--- a/src/request.coffee
+++ b/src/request.coffee
@@ -195,11 +195,13 @@ Request = (clientOptions={}) ->
             # Parse the Link headers
             # of the form `<http://a.com>; rel="next", <https://b.com?a=b&c=d>; rel="previous"`
             links = jqXHR.getResponseHeader('Link')
-            for part in links?.split(',') or []
-              [discard, href, rel] = part.match(/<([^>]+)>;\ rel="([^"]+)"/)
-              # Add the pagination functions on the JSON since Promises resolve one value
-              # Name the functions `nextPage`, `previousPage`, `firstPage`, `lastPage`
-              data["#{rel}_page_url"] = href
+            if links # For paged results return an object instead of an array so we can add the first/next/etc links
+              data = {items: data}
+              for part in links?.split(',') or []
+                [discard, href, rel] = part.match(/<([^>]+)>;\ rel="([^"]+)"/)
+                # Add the pagination functions on the JSON since Promises resolve one value
+                # Name the functions `nextPage`, `previousPage`, `firstPage`, `lastPage`
+                data["#{rel}_page_url"] = href
 
           else
             data = jqXHR.responseText

--- a/src/request.coffee
+++ b/src/request.coffee
@@ -195,7 +195,7 @@ Request = (clientOptions={}) ->
             # Parse the Link headers
             # of the form `<http://a.com>; rel="next", <https://b.com?a=b&c=d>; rel="previous"`
             links = jqXHR.getResponseHeader('Link')
-            if links # For paged results return an object instead of an array so we can add the first/next/etc links
+            if Array.isArray(data) # For paged results return an object instead of an array so we can add the first/next/etc links
               data = {items: data}
               for part in links?.split(',') or []
                 [discard, href, rel] = part.match(/<([^>]+)>;\ rel="([^"]+)"/)

--- a/test/object.spec.coffee
+++ b/test/object.spec.coffee
@@ -12,13 +12,13 @@ define ['chai', 'cs!./test-config'], ({assert, expect}, {client, USERNAME, TOKEN
     it 'has the same methods on octo.gists(ID).fetch().then(gist) as octo.gists.public.fetch().then(gists[0])', (done) ->
       client.gists.public.fetch()
       .then (gists) ->
-        expect(gists).to.not.be.empty
-        expect(gists[0].star.contains).to.be.a.function
+        expect(gists.items).to.not.be.empty
+        expect(gists.items[0].star.contains).to.be.a.function
         done()
 
     it 'has the same methods on octo.users(ID).fetch().then(user) as octo.users.fetch().then(users[0])', (done) ->
       client.users.fetch()
       .then (users) ->
-        expect(users).to.not.be.empty
-        expect(users[0].gists.fetch).to.be.a.function
+        expect(users.items).to.not.be.empty
+        expect(users.items[0].gists.fetch).to.be.a.function
         done()

--- a/test/object.spec.coffee
+++ b/test/object.spec.coffee
@@ -5,8 +5,8 @@ define ['chai', 'cs!./test-config'], ({assert, expect}, {client, USERNAME, TOKEN
     it 'has the same methods on octo.repos(REPO_ID).fetch().then(repo) as octo.me.repos.fetch().then(repos[0])', (done) ->
       client.me.repos.fetch()
       .then (repos) ->
-        expect(repos).to.not.be.empty
-        repos[0].forks.fetch()
+        expect(repos.items).to.not.be.empty
+        repos.items[0].forks.fetch()
         .then -> done()
 
     it 'has the same methods on octo.gists(ID).fetch().then(gist) as octo.gists.public.fetch().then(gists[0])', (done) ->

--- a/test/ruby-specs/commit-comments.spec.coffee
+++ b/test/ruby-specs/commit-comments.spec.coffee
@@ -15,7 +15,7 @@ define (require) ->
     it "returns a list of comments for a specific commit", (done) ->
       client.repos("sferik/rails_admin").commits("629e9fd9d4df25528e84d31afdc8ebeb0f56fbb3").comments.fetch()
       .then (commit_comments) ->
-        expect(commit_comments[0].user.login).to.equal("bbenezech")
+        expect(commit_comments.items[0].user.login).to.equal("bbenezech")
         done()
 
     it "returns a single commit comment", (done) ->
@@ -28,7 +28,7 @@ define (require) ->
       before (done) ->
         client.repos(test_repo).commits.fetch()
         .then (commits) =>
-          @commit = commits[0]
+          @commit = commits.items[0]
           client.repos(test_repo).commits(@commit.sha).comments.create({body:":metal:\n:sparkles:\n:cake:"})
           .then (@commit_comment) =>
             done()

--- a/test/ruby-specs/commits.spec.coffee
+++ b/test/ruby-specs/commits.spec.coffee
@@ -10,7 +10,7 @@ define (require) ->
     it "returns all commits", (done) ->
       client.repos("sferik/rails_admin").commits.fetch()
       .then (commits) ->
-        expect(commits[0].author).to.be.ok
+        expect(commits.items[0].author).to.be.ok
         done()
 
     # it "handles branch or sha argument", (done) ->
@@ -70,4 +70,3 @@ define (require) ->
         expect(comparison.baseCommit.sha).to.equal('0e0d7ae299514da692eb1cab741562c253d44188')
         expect(comparison.mergeBaseCommit.sha).to.equal('b7b37f75a80b8e84061cd45b246232ad958158f5')
         done()
-

--- a/test/ruby-specs/commits.spec.coffee
+++ b/test/ruby-specs/commits.spec.coffee
@@ -41,7 +41,8 @@ define (require) ->
     it "creates a commit", (done) ->
       client.repos(test_repo).commits.fetch()
       .then (commits) ->
-        last_commit = commits[commits.length-1]
+        {items} = commits
+        last_commit = items[items.length-1]
 
         client.repos(test_repo).git.commits.create({message: "My commit message", tree:last_commit.commit.tree.sha, parents:[last_commit.sha]})
         .then () -> done()
@@ -52,7 +53,8 @@ define (require) ->
         repo = client.repos(test_repo)
         repo.commits.fetch()
         .then (commits) ->
-          last_commit = commits[commits.length-1]
+          {items} = commits
+          last_commit = items[items.length-1]
           repo.git.refs.create({ref:"refs/heads/branch-to-merge", sha:last_commit.sha})
           .then (v) ->
             head = 'master'

--- a/test/ruby-specs/downloads.spec.coffee
+++ b/test/ruby-specs/downloads.spec.coffee
@@ -10,7 +10,8 @@ define (require) ->
     it "lists available downloads", (done) ->
       client.repos("github/hubot").downloads.fetch()
       .then (downloads) ->
-        expect(downloads[downloads.length-1].description).to.equal("Version 1.0.0 of the Hubot Campfire Bot")
+        {items} = downloads
+        expect(items[items.length-1].description).to.equal("Version 1.0.0 of the Hubot Campfire Bot")
         done()
 
     it "gets a single download", (done) ->

--- a/test/simple.spec.coffee
+++ b/test/simple.spec.coffee
@@ -272,8 +272,8 @@ define ['chai', 'cs!./test-config'], ({assert, expect}, {Octokat, client, USERNA
 
         it '.git.refs.tags.fetch()', () ->
           STATE[GH].repos('philschatz', 'octokat.js').git.refs.tags.fetch().then (tags) ->
-            expect(tags).to.be.a('array')
-            expect(tags.length).to.equal(17)
+            expect(tags.items).to.be.a('array')
+            expect(tags.items.length).to.equal(17)
 
         it '.git.refs.tags("v0.1.1").fetch()', () ->
           STATE[GH].repos('philschatz', 'octokat.js').git.refs.tags('v0.1.1').fetch().then (tag) ->


### PR DESCRIPTION
## :warning: Introduces Breaking Changes :warning:

Currently fetching paged results yields an array with extra fields slapped on. For example, fetching the list of commits for a repo would yield an array with extra functions (like `nextPage()` and `lastPage()`) on it.

Instead, this makes paged results return an object with the following structure:

```js
{
  items: [ ... ],           // the results
  nextPage: function(),     // the following are included only when GitHub provides them
  lastPage: function(),
  firstPage: function(),
  prevPage: function()
}
```

### Motivation

- Slapping extra functions onto an array, while *cool* is not very discoverable and it makes serializing the object (ie to add to `sessionStorage` for caching) much more difficult
- When `disableHypermedia` is set then there is no way to get the link headers

## TODO

- [x] Always convert an Array returned by GitHub to `{items: [...]}` even when there are no link headers