### PR TITLE
Fix resource upload url pattern

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -116,6 +116,7 @@ module.exports = (grunt) ->
           'dist/node/grammar.js'        : 'src/grammar.coffee'
           'dist/node/helper-base64.js'  : 'src/helper-base64.coffee'
           'dist/node/helper-promise.js' : 'src/helper-promise.coffee'
+          'dist/node/helper-querystring.js' : 'src/helper-querystring.coffee'
           'dist/node/octokat.js'        : 'src/octokat.coffee'
           'dist/node/plus.js'           : 'src/plus.coffee'
           'dist/node/replacer.js'       : 'src/replacer.coffee'

--- a/dist/octokat.js
+++ b/dist/octokat.js
@@ -780,7 +780,7 @@ Replacer = (function() {
     if (/_url$/.test(key)) {
       fn = (function(_this) {
         return function() {
-          var args, cb, contentType, data, i, m, match, optionalNames, param, ref1, url;
+          var args, cb, contentType, data, i, j, len, m, match, optionalNames, param, paramName, ref1, ref2, url;
           cb = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
           if (!(/\{/.test(value) || /_page_url$/.test(key))) {
             console.warn('Deprecation warning: Use the .fooUrl field instead of calling the method');
@@ -797,10 +797,20 @@ Replacer = (function() {
                   break;
                 case '?':
                   optionalNames = match.slice(2, -1).split(',');
-                  if (typeof param === 'string') {
-                    param = "?" + optionalNames[0] + "=" + param;
-                  } else {
+                  if (typeof param === 'object') {
+                    if (Object.keys(param).length === 0) {
+                      console.warn('Must pass in a dictionary with at least one key when there are multiple optional params');
+                    }
+                    ref1 = Object.keys(param);
+                    for (j = 0, len = ref1.length; j < len; j++) {
+                      paramName = ref1[j];
+                      if (optionalNames.indexOf(paramName) < 0) {
+                        console.warn("Invalid parameter '" + paramName + "' passed in as argument");
+                      }
+                    }
                     param = toQueryString(param);
+                  } else {
+                    param = "?" + optionalNames[0] + "=" + param;
                   }
               }
             } else {
@@ -813,7 +823,7 @@ Replacer = (function() {
             i++;
           }
           if (/upload_url$/.test(key)) {
-            ref1 = args.slice(-2), contentType = ref1[0], data = ref1[1];
+            ref2 = args.slice(-2), contentType = ref2[0], data = ref2[1];
             return _this._request('POST', url, data, {
               contentType: contentType,
               raw: true

--- a/dist/octokat.js
+++ b/dist/octokat.js
@@ -8,19 +8,7 @@ plus = require('./plus');
 
 toPromise = require('./helper-promise').toPromise;
 
-toQueryString = function(options) {
-  var key, params, ref, value;
-  if (!options || options === {}) {
-    return '';
-  }
-  params = [];
-  ref = options || {};
-  for (key in ref) {
-    value = ref[key];
-    params.push(key + "=" + (encodeURIComponent(value)));
-  }
-  return "?" + (params.join('&'));
-};
+toQueryString = require('./helper-querystring');
 
 URL_TESTER = function(path) {
   var err;
@@ -123,7 +111,7 @@ Chainer = function(request, _path, name, contextTree, fn) {
 module.exports = Chainer;
 
 
-},{"./grammar":2,"./helper-promise":4,"./plus":6}],2:[function(require,module,exports){
+},{"./grammar":2,"./helper-promise":4,"./helper-querystring":5,"./plus":7}],2:[function(require,module,exports){
 var DEFAULT_HEADER, OBJECT_MATCHER, PREVIEW_HEADERS, TREE_OPTIONS, URL_VALIDATOR;
 
 URL_VALIDATOR = /^(https?:\/\/[^\/]+)?(\/api\/v3)?\/(zen|octocat|users|organizations|issues|gists|emojis|markdown|meta|rate_limit|feeds|events|notifications|notifications\/threads(\/[^\/]+)|notifications\/threads(\/[^\/]+)\/subscription|gitignore\/templates(\/[^\/]+)?|user|user\/(repos|orgs|followers|following(\/[^\/]+)?|emails(\/[^\/]+)?|issues|starred|starred(\/[^\/]+){2}|teams)|orgs\/[^\/]+|orgs\/[^\/]+\/(repos|issues|members|events|teams)|teams\/[^\/]+|teams\/[^\/]+\/(members(\/[^\/]+)?|memberships\/[^\/]+|repos|repos(\/[^\/]+){2})|users\/[^\/]+|users\/[^\/]+\/(repos|orgs|gists|followers|following(\/[^\/]+){0,2}|keys|starred|received_events(\/public)?|events(\/public)?|events\/orgs\/[^\/]+)|search\/(repositories|issues|users|code)|gists\/(public|starred|([a-f0-9]{20}|[0-9]+)|([a-f0-9]{20}|[0-9]+)\/forks|([a-f0-9]{20}|[0-9]+)\/comments(\/[0-9]+)?|([a-f0-9]{20}|[0-9]+)\/star)|repos(\/[^\/]+){2}|repos(\/[^\/]+){2}\/(readme|tarball(\/[^\/]+)?|zipball(\/[^\/]+)?|compare\/([^\.{3}]+)\.{3}([^\.{3}]+)|deployments(\/[0-9]+)?|deployments\/[0-9]+\/statuses(\/[0-9]+)?|hooks|hooks\/[^\/]+|hooks\/[^\/]+\/tests|assignees|languages|teams|tags|branches(\/[^\/]+){0,2}|contributors|subscribers|subscription|stargazers|comments(\/[0-9]+)?|downloads(\/[0-9]+)?|forks|milestones|milestones\/[0-9]+|milestones\/[0-9]+\/labels|labels(\/[^\/]+)?|releases|releases\/([0-9]+)|releases\/([0-9]+)\/assets|releases\/latest|releases\/tags\/([^\/]+)|releases\/assets\/([0-9]+)|events|notifications|merges|statuses\/[a-f0-9]{40}|pages|pages\/builds|pages\/builds\/latest|commits|commits\/[a-f0-9]{40}|commits\/[a-f0-9]{40}\/(comments|status|statuses)?|contents\/|contents(\/[^\/]+)*|collaborators(\/[^\/]+)?|(issues|pulls)|(issues|pulls)\/(events|events\/[0-9]+|comments(\/[0-9]+)?|[0-9]+|[0-9]+\/events|[0-9]+\/comments|[0-9]+\/labels(\/[^\/]+)?)|pulls\/[0-9]+\/(files|commits)|git\/(refs|refs\/(.+|heads(\/[^\/]+)?|tags(\/[^\/]+)?)|trees(\/[^\/]+)?|blobs(\/[a-f0-9]{40}$)?|commits(\/[a-f0-9]{40}$)?)|stats\/(contributors|commit_activity|code_frequency|participation|punch_card))|licenses|licenses\/([^\/]+)|authorizations|authorizations\/((\d+)|clients\/([^\/]{20})|clients\/([^\/]{20})\/([^\/]+))|applications\/([^\/]{20})\/tokens|applications\/([^\/]{20})\/tokens\/([^\/]+)|enterprise\/(settings\/license|stats\/(issues|hooks|milestones|orgs|comments|pages|users|gists|pulls|repos|all))|staff\/indexing_jobs|users\/[^\/]+\/(site_admin|suspended)|setup\/api\/(start|upgrade|configcheck|configure|settings(authorized-keys)?|maintenance))$/;
@@ -511,6 +499,26 @@ module.exports = {
 
 
 },{}],5:[function(require,module,exports){
+var toQueryString;
+
+toQueryString = function(options) {
+  var key, params, ref, value;
+  if (!options || options === {}) {
+    return '';
+  }
+  params = [];
+  ref = options || {};
+  for (key in ref) {
+    value = ref[key];
+    params.push(key + "=" + (encodeURIComponent(value)));
+  }
+  return "?" + (params.join('&'));
+};
+
+module.exports = toQueryString;
+
+
+},{}],6:[function(require,module,exports){
 (function (global){
 var Chainer, OBJECT_MATCHER, Octokat, Replacer, Request, TREE_OPTIONS, plus, reChainChildren, ref, toPromise;
 
@@ -620,7 +628,7 @@ module.exports = Octokat;
 
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./chainer":1,"./grammar":2,"./helper-promise":4,"./plus":6,"./replacer":7,"./request":8}],6:[function(require,module,exports){
+},{"./chainer":1,"./grammar":2,"./helper-promise":4,"./plus":7,"./replacer":8,"./request":9}],7:[function(require,module,exports){
 var plus;
 
 plus = {
@@ -662,13 +670,15 @@ plus = {
 module.exports = plus;
 
 
-},{}],7:[function(require,module,exports){
-var Chainer, OBJECT_MATCHER, Replacer, TREE_OPTIONS, plus, ref, toPromise,
+},{}],8:[function(require,module,exports){
+var Chainer, OBJECT_MATCHER, Replacer, TREE_OPTIONS, plus, ref, toPromise, toQueryString,
   slice = [].slice;
 
 plus = require('./plus');
 
 toPromise = require('./helper-promise').toPromise;
+
+toQueryString = require('./helper-querystring');
 
 ref = require('./grammar'), TREE_OPTIONS = ref.TREE_OPTIONS, OBJECT_MATCHER = ref.OBJECT_MATCHER;
 
@@ -787,7 +797,11 @@ Replacer = (function() {
                   break;
                 case '?':
                   optionalNames = match.slice(2, -1).split(',');
-                  param = "?" + optionalNames[0] + "=" + param;
+                  if (typeof param === 'string') {
+                    param = "?" + optionalNames[0] + "=" + param;
+                  } else {
+                    param = toQueryString(param);
+                  }
               }
             } else {
               param = '';
@@ -830,7 +844,7 @@ Replacer = (function() {
 module.exports = Replacer;
 
 
-},{"./chainer":1,"./grammar":2,"./helper-promise":4,"./plus":6}],8:[function(require,module,exports){
+},{"./chainer":1,"./grammar":2,"./helper-promise":4,"./helper-querystring":5,"./plus":7}],9:[function(require,module,exports){
 var DEFAULT_HEADER, ETagResponse, Request, ajax, base64encode, userAgent;
 
 base64encode = require('./helper-base64');
@@ -1079,5 +1093,5 @@ Request = function(clientOptions) {
 module.exports = Request;
 
 
-},{"./grammar":2,"./helper-base64":3}]},{},[5])(5)
+},{"./grammar":2,"./helper-base64":3}]},{},[6])(6)
 });

--- a/dist/octokat.js
+++ b/dist/octokat.js
@@ -770,7 +770,7 @@ Replacer = (function() {
     if (/_url$/.test(key)) {
       fn = (function(_this) {
         return function() {
-          var args, cb, contentType, data, i, m, match, param, ref1, url;
+          var args, cb, contentType, data, i, m, match, optionalNames, param, ref1, url;
           cb = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
           if (!(/\{/.test(value) || /_page_url$/.test(key))) {
             console.warn('Deprecation warning: Use the .fooUrl field instead of calling the method');
@@ -786,7 +786,8 @@ Replacer = (function() {
                   param = "/" + param;
                   break;
                 case '?':
-                  param = "?" + match.slice(2, -1) + "=" + param;
+                  optionalNames = match.slice(2, -1).split(',');
+                  param = "?" + optionalNames[0] + "=" + param;
               }
             } else {
               param = '';

--- a/src/chainer.coffee
+++ b/src/chainer.coffee
@@ -1,26 +1,13 @@
 {URL_VALIDATOR} = require './grammar'
 plus = require './plus'
 {toPromise} = require './helper-promise'
+toQueryString = require './helper-querystring'
 
 # Daisy-Chainer
 # ===============================
 #
 # Generates the functions so `octo.repos(...).issues.comments.fetch()` works.
 # Constructs a URL for the verb methods (like `.fetch` and `.create`).
-
-
-
-# Converts a dictionary to a query string.
-# Internal helper method
-toQueryString = (options) ->
-
-  # Returns '' if `options` is empty so this string can always be appended to a URL
-  return '' if not options or options is {}
-
-  params = []
-  for key, value of options or {}
-    params.push "#{key}=#{encodeURIComponent(value)}"
-  return "?#{params.join('&')}"
 
 
 # Test if the path is constructed correctly

--- a/src/helper-querystring.coffee
+++ b/src/helper-querystring.coffee
@@ -1,0 +1,13 @@
+# Converts a dictionary to a query string.
+# Internal helper method
+toQueryString = (options) ->
+
+  # Returns '' if `options` is empty so this string can always be appended to a URL
+  return '' if not options or options is {}
+
+  params = []
+  for key, value of options or {}
+    params.push "#{key}=#{encodeURIComponent(value)}"
+  return "?#{params.join('&')}"
+
+module.exports = toQueryString

--- a/src/replacer.coffee
+++ b/src/replacer.coffee
@@ -88,10 +88,13 @@ class Replacer
                 param = "/#{param}"
               when '?'
                 # Strip off the "{?" and the trailing "}"
-                # For example, the URL is `/assets{?name}`
+                # For example, the URL is `/assets{?name,label}`
                 #   which turns into `/assets?name=foo.zip`
                 # Used to upload releases via the repo releases API.
-                param = "?#{match[2..-2]}=#{param}"
+                # TODO: When match contains `,` or
+                # `args.length is 1` and args[0] is object match the args to those in the template
+                optionalNames = match[2..-2].split(',')
+                param = "?#{optionalNames[0]}=#{param}"
           else
             # Discard the remaining optional params in the URL
             param = ''

--- a/src/replacer.coffee
+++ b/src/replacer.coffee
@@ -96,11 +96,16 @@ class Replacer
                 # `args.length is 1` and args[0] is object match the args to those in the template
                 optionalNames = match[2..-2].split(',')
                 # If param is a string then just use the 1st optionalName
-                if typeof param is 'string'
-                  param = "?#{optionalNames[0]}=#{param}"
-                else
+                if typeof param is 'object'
                   # TODO: validate the optionalNames
+                  if Object.keys(param).length is 0
+                    console.warn('Must pass in a dictionary with at least one key when there are multiple optional params')
+                  for paramName in Object.keys(param)
+                    if optionalNames.indexOf(paramName) < 0
+                      console.warn("Invalid parameter '#{paramName}' passed in as argument")
                   param = toQueryString(param)
+                else
+                  param = "?#{optionalNames[0]}=#{param}"
 
           else
             # Discard the remaining optional params in the URL

--- a/src/replacer.coffee
+++ b/src/replacer.coffee
@@ -1,5 +1,6 @@
 plus = require './plus'
 {toPromise} = require './helper-promise'
+toQueryString = require './helper-querystring'
 {TREE_OPTIONS, OBJECT_MATCHER} = require './grammar'
 Chainer = require './chainer'
 
@@ -94,7 +95,13 @@ class Replacer
                 # TODO: When match contains `,` or
                 # `args.length is 1` and args[0] is object match the args to those in the template
                 optionalNames = match[2..-2].split(',')
-                param = "?#{optionalNames[0]}=#{param}"
+                # If param is a string then just use the 1st optionalName
+                if typeof param is 'string'
+                  param = "?#{optionalNames[0]}=#{param}"
+                else
+                  # TODO: validate the optionalNames
+                  param = toQueryString(param)
+
           else
             # Discard the remaining optional params in the URL
             param = ''

--- a/test/node.coffee
+++ b/test/node.coffee
@@ -2,5 +2,7 @@ path = require('path')
 sepia = require('sepia')
 require('./all')
 
+require('./replacer.spec')
+
 sepia.fixtureDir(path.join(__dirname, '..', 'node_modules', 'octokat-fixtures', 'fixtures'))
 sepia.configure(includeHeaderNames:false)

--- a/test/replacer.spec.coffee
+++ b/test/replacer.spec.coffee
@@ -1,0 +1,32 @@
+define = window?.define or (deps, cb) -> cb((require(dep.replace('cs!', '')) for dep in deps)...)
+define ['chai', 'cs!../src/replacer'], ({assert, expect}, Replacer) ->
+
+  describe 'URL Patterns (only tested in Node)', ->
+
+    PATTERN = 'https://foo{?name,label}'
+    CONTENT_TYPE = 'application/javascript'
+    CONTENT = 'js_contents()'
+
+    it 'supports a single optional arg', (done) ->
+      EXPECTED_URL = 'https://foo?name=build.js'
+      request = (method, url, content, {contentType, raw}) ->
+        expect(url).to.equal(EXPECTED_URL)
+        expect(content).to.equal(CONTENT)
+        expect(contentType).to.equal(CONTENT_TYPE)
+        expect(raw).to.be.true
+        done()
+      r = new Replacer(request)
+      o = r.replace({upload_url: PATTERN})
+      o.upload('build.js', CONTENT_TYPE, CONTENT)
+
+    it 'supports multiple optional args', (done) ->
+      EXPECTED_URL = 'https://foo?name=build.js&label=MY%20LABEL'
+      request = (method, url, content, {contentType, raw}) ->
+        expect(url).to.equal(EXPECTED_URL)
+        expect(content).to.equal(CONTENT)
+        expect(contentType).to.equal(CONTENT_TYPE)
+        expect(raw).to.be.true
+        done()
+      r = new Replacer(request)
+      o = r.replace({upload_url: PATTERN})
+      o.upload({name: 'build.js', label: 'MY LABEL'}, CONTENT_TYPE, CONTENT)

--- a/test/replacer.spec.coffee
+++ b/test/replacer.spec.coffee
@@ -3,7 +3,7 @@ define ['chai', 'cs!../src/replacer'], ({assert, expect}, Replacer) ->
 
   describe 'URL Patterns (only tested in Node)', ->
 
-    PATTERN = 'https://foo{?name,label}'
+    URL_PATTERN = 'https://foo{?name,label}'
     CONTENT_TYPE = 'application/javascript'
     CONTENT = 'js_contents()'
 
@@ -16,8 +16,20 @@ define ['chai', 'cs!../src/replacer'], ({assert, expect}, Replacer) ->
         expect(raw).to.be.true
         done()
       r = new Replacer(request)
-      o = r.replace({upload_url: PATTERN})
+      o = r.replace({upload_url: URL_PATTERN})
       o.upload('build.js', CONTENT_TYPE, CONTENT)
+
+    it 'supports a single optional arg which is not a string', (done) ->
+      EXPECTED_URL = 'https://foo?name=1234'
+      request = (method, url, content, {contentType, raw}) ->
+        expect(url).to.equal(EXPECTED_URL)
+        expect(content).to.equal(CONTENT)
+        expect(contentType).to.equal(CONTENT_TYPE)
+        expect(raw).to.be.true
+        done()
+      r = new Replacer(request)
+      o = r.replace({upload_url: URL_PATTERN})
+      o.upload(1234, CONTENT_TYPE, CONTENT)
 
     it 'supports multiple optional args', (done) ->
       EXPECTED_URL = 'https://foo?name=build.js&label=MY%20LABEL'
@@ -28,5 +40,5 @@ define ['chai', 'cs!../src/replacer'], ({assert, expect}, Replacer) ->
         expect(raw).to.be.true
         done()
       r = new Replacer(request)
-      o = r.replace({upload_url: PATTERN})
+      o = r.replace({upload_url: URL_PATTERN})
       o.upload({name: 'build.js', label: 'MY LABEL'}, CONTENT_TYPE, CONTENT)


### PR DESCRIPTION
fixes #72. The `upload_url` pattern changed and an additional optional argument was added which broke the pattern matcher. This fixes the immediate problem of not being able to upload resources. This solution should (hopefully) work for GitHub Enterprise 2.3 and 2.4

TODO:

- [x] functions generated from URL patterns that contain multiple optional arguments should take a single arg, an Object