### PR TITLE
add support for using a URL directly

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -121,6 +121,7 @@ module.exports = (grunt) ->
           'dist/node/plus.js'           : 'src/plus.coffee'
           'dist/node/replacer.js'       : 'src/replacer.coffee'
           'dist/node/request.js'        : 'src/request.coffee'
+          'dist/node/verb-methods.js'   : 'src/verb-methods.coffee'
 
 
   # Dependencies

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This package can be used in `nodejs` **or** in the browser as an AMD module or u
   - [Using EcmaScript 6 Generators](#using-ecmascript-6-generators)
   - [Uploading Releases](#uploading-releases)
   - [Parsing JSON](#parsing-json)
+  - [Using URLs Directly](#using-urls-directly)
   - [Development](#development)
 
 
@@ -418,6 +419,20 @@ repo.releases(123456).fetch()
 
 If you are using webhooks, the JSON returned by GitHub can be parsed using
 `octo.parse(json)` to return a rich object with all the methods Octokat provides.
+
+## Using URLs Directly
+
+Instead of using Octokat to construct URLs, you can construct them yourself and
+still use Octokat for sending authentication information, caching, pagination,
+and parsing Hypermedia.
+
+```js
+// Specify the entire URL
+octo.fromUrl("https://api.github.com/repos/philschatz/octokat.js/issues/1").fetch(cb);
+
+// Or, just the path
+octo.fromUrl("/repos/philschatz/octokat.js/issues").fetch({state: 'open'}, cb);
+```
 
 ## Development
 

--- a/src/helper-promise.coffee
+++ b/src/helper-promise.coffee
@@ -85,7 +85,7 @@ else
 toPromise = (orig) ->
   return (args...) ->
     last = args[args.length - 1]
-    if typeof last is 'function'
+    if typeof last is 'function' # The last arg is a callback function
       args.pop()
       return orig(last, args...)
     else if newPromise

--- a/src/verb-methods.coffee
+++ b/src/verb-methods.coffee
@@ -1,0 +1,34 @@
+{URL_VALIDATOR} = require './grammar'
+{toPromise} = require './helper-promise'
+toQueryString = require './helper-querystring'
+
+# Test if the path is constructed correctly
+URL_TESTER = (path) ->
+  unless URL_VALIDATOR.test(path)
+    err = "BUG: Invalid Path. If this is actually a valid path then please update the URL_VALIDATOR. path=#{path}"
+    console.warn(err)
+
+
+injectVerbMethods = (request, path, obj) ->
+  verbs =
+    fetch      : (cb, config) ->   request('GET', "#{path}#{toQueryString(config)}", null, {}, cb)
+    read       : (cb, config) ->   request('GET', "#{path}#{toQueryString(config)}", null, {raw:true}, cb)
+    readBinary : (cb, config) ->   request('GET', "#{path}#{toQueryString(config)}", null, {raw:true, isBase64:true}, cb)
+    remove     : (cb, config) ->   request('DELETE', path, config, {isBoolean:true}, cb)
+    create     : (cb, config, isRaw) -> request('POST', path, config, {raw:isRaw}, cb)
+    update     : (cb, config) ->   request('PATCH', path, config, null, cb)
+    add        : (cb, config) ->   request('PUT', path, config, {isBoolean:true}, cb)
+    contains   : (cb, args...) ->  request('GET', "#{path}/#{args.join('/')}", null, {isBoolean:true}, cb)
+
+  # Allow all the verb methods to accept a callback as the last arg
+  for verbName, verbFunc of verbs
+    # For development, validate the URL
+    do (verbName, verbFunc) ->
+      obj[verbName] = (args...) ->
+        URL_TESTER(path)
+        return toPromise(verbFunc)(args...)
+    # For production do not validate the URL
+    # obj[verbName] = toPromise(verbFunc)
+
+
+module.exports = injectVerbMethods

--- a/test/simple.spec.coffee
+++ b/test/simple.spec.coffee
@@ -128,6 +128,18 @@ define ['chai', 'cs!./test-config'], ({assert, expect}, {Octokat, client, USERNA
       STATE[GH] = client
 
     describe 'Synchronous methods', () ->
+      it "supports octo.fromUrl('https://api.github.com/repos/#{REPO_USER}/#{REPO_NAME}')", (done) ->
+        client.fromUrl("https://api.github.com/repos/#{REPO_USER}/#{REPO_NAME}")
+        .fetch().then (val) ->
+          expect(val).to.not.be.null
+          done()
+
+      it "supports octo.fromUrl('/repos/#{REPO_USER}/#{REPO_NAME}')", (done) ->
+        client.fromUrl("/repos/#{REPO_USER}/#{REPO_NAME}")
+        .fetch().then (val) ->
+          expect(val).to.not.be.null
+          done()
+
       it 'supports octo.parse(json)', () ->
         json =
           url: 'https://api.github.com/repos/philschatz/octokat.js'


### PR DESCRIPTION
fixes #76

Add support for supporting URLs directly instead of using Octokat to construct them.

You can still use Octokat for sending authentication information, caching, pagination,
and parsing Hypermedia.

```js
// Specify the entire URL
octo.fromUrl("https://api.github.com/repos/philschatz/octokat.js/issues/1").fetch(cb);

// Or, just the path
octo.fromUrl("/repos/philschatz/octokat.js/issues").fetch({state: 'open'}, cb);
```