### PR TITLE
add REPL example using tonicdev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Dependency Status](https://david-dm.org/philschatz/octokat.js/status.svg)](https://david-dm.org/philschatz/octokat.js)
 [![devDependency Status](https://david-dm.org/philschatz/octokat.js/dev-status.svg)](https://david-dm.org/philschatz/octokat.js#info=devDependencies)
 
-[Try it out in your browser!](https://tonicdev.com/npm/octokat) (REPL)
+<a href="https://tonicdev.com/npm/octokat" target="_window">Try it out in your browser!</a> (REPL)
 
 Octokat.js provides a minimal higher-level wrapper around [GitHub's API](https://developer.github.com).
 It is being developed in the context of an [EPUB3 Textbook editor for GitHub](https://github.com/oerpub/github-bookeditor)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![Dependency Status](https://david-dm.org/philschatz/octokat.js/status.svg)](https://david-dm.org/philschatz/octokat.js)
 [![devDependency Status](https://david-dm.org/philschatz/octokat.js/dev-status.svg)](https://david-dm.org/philschatz/octokat.js#info=devDependencies)
 
+[Try it out in your browser!](https://tonicdev.com/npm/octokat) (REPL)
+
 Octokat.js provides a minimal higher-level wrapper around [GitHub's API](https://developer.github.com).
 It is being developed in the context of an [EPUB3 Textbook editor for GitHub](https://github.com/oerpub/github-bookeditor)
  and a [simple serverless kanban board](https://github.com/philschatz/gh-board) ([demo](http://philschatz.com/gh-board)).

--- a/example-tonic.js
+++ b/example-tonic.js
@@ -1,0 +1,15 @@
+octo = require('octokat')(/* Config options would go here */)
+
+// Fetch the info for a repository
+repoInfo = await octo.repos('philschatz/octokat.js').fetch()
+
+// Fetch all the open issues for a repository (2 methods):
+
+// 1. Directly
+//openIssues = await octo.repos('philschatz/octokat.js').issues.fetch({state: 'open'})
+
+// 2. Using Hypermedia (URL patterns from GitHub)
+openIssues = await repoInfo.issues.fetch({state: 'open'})
+
+// Output all the issues
+openIssues.map(function(issue) { return issue.title; })

--- a/example-tonic.js
+++ b/example-tonic.js
@@ -13,3 +13,6 @@ openIssues = await repoInfo.issues.fetch({state: 'open'})
 
 // Output all the issues
 openIssues.map(function(issue) { return issue.title; })
+
+
+// For more examples see https://github.com/philschatz/octokat.js/blob/master/examples.md

--- a/package.json
+++ b/package.json
@@ -57,5 +57,6 @@
   "directories": {
     "test": "test"
   },
+  "tonicExampleFilename": "examples/tonic-example.js",
   "license": "MIT"
 }


### PR DESCRIPTION
Adds a link at the top of `README.md` to _Try Before You Buy_<sup>TM</sup> with simple example code that lists all the open issues for a repository.

Once a new version is published to `npm` the example should load up at https://tonicdev.com/npm/octokat