### PR TITLE
Add webpack support

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,9 @@
     "test": "test"
   },
   "tonicExampleFilename": "examples/tonic-example.js",
+  "browser": {
+    "fs": false,
+    "child_process": false
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
Remove errors when using octokat with webpack (client side)

``` bash
ERROR in ./~/octokat/~/xmlhttprequest/lib/XMLHttpRequest.js
Module not found: Error: Cannot resolve module 'child_process' in /Users/.../node_modules/octokat/node_modules/xmlhttprequest/lib
 @ ./~/octokat/~/xmlhttprequest/lib/XMLHttpRequest.js 15:12-36

ERROR in ./~/octokat/~/xmlhttprequest/lib/XMLHttpRequest.js
Module not found: Error: Cannot resolve module 'fs' in /Users/.../node_modules/octokat/node_modules/xmlhttprequest/lib
 @ ./~/octokat/~/xmlhttprequest/lib/XMLHttpRequest.js 16:9-22
webpack: bundle is now VALID.
```
