### PR TITLE
Fix gammar for /repos/:org/:name/(commits|statuses)/:ref

### DIFF
--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -125,7 +125,7 @@ URL_VALIDATOR = /// ^
         | events
         | notifications
         | merges
-        | statuses / [a-f0-9]{40}
+        | statuses / [^/]+
         | pages
         | pages / builds
         | pages / builds / latest

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -130,8 +130,8 @@ URL_VALIDATOR = /// ^
         | pages / builds
         | pages / builds / latest
         | commits
-        | commits / [a-f0-9]{40}
-        | commits / [a-f0-9]{40} / (
+        | commits / [^/]+
+        | commits / [^/]+ / (
               comments
             | status
             | statuses


### PR DESCRIPTION
In both cases it's allowed to use the name of a branch:

- `curl -s https://api.github.com/repos/michaelcontento/circleci-matrix/statuses/master`
- `curl -s https://api.github.com/repos/michaelcontento/circleci-matrix/commits/master`
- `curl -s https://api.github.com/repos/michaelcontento/circleci-matrix/commits/master/status`