### PR TITLE
Removing the "If-Modified-Since" request header when the cache is empty (as it causes issues)

### DIFF
--- a/dist/octokat.js
+++ b/dist/octokat.js
@@ -932,8 +932,6 @@ Request = function(clientOptions) {
     }
     if (cacheHandler.get(method, path)) {
       headers['If-None-Match'] = cacheHandler.get(method, path).eTag;
-    } else {
-      headers['If-Modified-Since'] = 'Thu, 01 Jan 1970 00:00:00 GMT';
     }
     if (clientOptions.token || (clientOptions.username && clientOptions.password)) {
       if (clientOptions.token) {

--- a/src/request.coffee
+++ b/src/request.coffee
@@ -110,14 +110,6 @@ Request = (clientOptions={}) ->
     # Send the ETag if re-requesting a URL
     if cacheHandler.get(method, path)
       headers['If-None-Match'] = cacheHandler.get(method, path).eTag
-    else
-      # The browser will sneak in a 'If-Modified-Since' header if the GET has been requested before
-      # but for some reason the cached response does not seem to be available
-      # in the jqXHR object.
-      # So, the first time a URL is requested set this date to 0 so we always get a response the 1st time
-      # a URL is requested.
-      headers['If-Modified-Since'] = 'Thu, 01 Jan 1970 00:00:00 GMT'
-
 
     if (clientOptions.token) or (clientOptions.username and clientOptions.password)
       if clientOptions.token


### PR DESCRIPTION
octokat failed today on my machine because GitHub returned a 304 status code when the cache was empty. I think that sending an "If-Modified-Since" header is wrong when we don't expect a 304 response status. Removing the "If-Modified-Since" header in the request fixed my issue, that's why I am opening this pull request

Here is a js file with which you can reproduce the issue on node.js (after making sure the `co` and `octokat` npm packages are installed):

```js
"use strict";

const co = require("co");
const Octokat = require("octokat");

co(function * () {
    const octokat = new Octokat({
       // note that I used a token here because my ip was otherwise rate-limited 
    });
    const response = yield octokat.repos("ariatemplates", "ariatemplates").commits.fetch({
        sha: "master"
    });
    console.log(response);
}).catch(function (error) {
    console.log("Error", error);
});
```

Here is the output I got:
```
D:\git_clones\t\test\node_modules\octokat\dist\node\plugins\cache-handler.js:51
            throw new Error('ERROR: Bug in Octokat cacheHandler. It had an eTag but not the cached response');
            ^

Error: ERROR: Bug in Octokat cacheHandler. It had an eTag but not the cached response
    at CacheHandler.module.exports.CacheHandler.responseMiddleware (D:\git_clones\t\test\node_modules\octokat\dist\node\plugins\cache-han
dler.js:51:19)
    at Object.instance._parseWithContext (D:\git_clones\t\test\node_modules\octokat\dist\node\base.js:124:39)
    at D:\git_clones\t\test\node_modules\octokat\dist\node\requester.js:207:38
    at xhr.onreadystatechange (D:\git_clones\t\test\node_modules\octokat\dist\node\requester.js:37:18)
    at dispatchEvent (D:\git_clones\t\test\node_modules\xmlhttprequest\lib\XMLHttpRequest.js:591:25)
    at setState (D:\git_clones\t\test\node_modules\xmlhttprequest\lib\XMLHttpRequest.js:610:14)
    at IncomingMessage.<anonymous> (D:\git_clones\t\test\node_modules\xmlhttprequest\lib\XMLHttpRequest.js:447:13)
    at emitNone (events.js:72:20)
    at IncomingMessage.emit (events.js:166:7)
    at endReadableNT (_stream_readable.js:903:12)
```

I tried with version 0.5.0-beta.0 of octokat but previous versions also failed in a different way (returning an empty string instead of an error).

Note that I have successfully used the octokat package several times with requests similar to this one, so this issue probably comes from a change on GitHub servers.

Thank you in advance for taking this pull request into account.
Thank you for the great work you are doing by providing octokat to the community!