### PR TITLE
Allow calls to methods without arguments

### DIFF
--- a/src/chainer.coffee
+++ b/src/chainer.coffee
@@ -9,7 +9,7 @@ injectVerbMethods = require './verb-methods'
 
 Chainer = (request, path, name, contextTree, fn) ->
   fn ?= (args...) ->
-    throw new Error('BUG! must be called with at least one argument') unless args.length
+    return Chainer(request, path, name, contextTree) unless args.length
     # Special-case compare because its args turn into '...' instead of the usual '/'
     if name is 'compare'
       separator = '...'


### PR DESCRIPTION
Methods like [List issues](https://developer.github.com/v3/issues/#list-issues) don't require any arguments but octokat fails for such calls:

    > octo.repos('philschatz', 'octokat.js').issues().comments().fetch()
     BUG! must be called with at least one argument

This change removes the exception and returns a useful path instead.

Closes #110