### PR TITLE
Mention per_page parameter in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,12 @@ octo.repos('philschatz', 'octokat.js').commits.fetch()
   .then (moreCommits) ->
     console.log('2nd page of results', moreCommits)
 ```
+As standard with the Github API, passing a `per_page` parameter allows you to control the number of results per page. For example:
+
+```js
+octo.repos('philschatz', 'octokat.js').issues.fetch({per_page: 100})
+  .then(...)
+```
 
 ## Preview new APIs
 


### PR DESCRIPTION
It took me a minute to realise I could use the Github API's per_page parameter in fetch(), so proposing to document it for others.