### PR TITLE
add routes for the Projects API

### DIFF
--- a/src/grammar/preview-headers.coffee
+++ b/src/grammar/preview-headers.coffee
@@ -34,6 +34,25 @@ module.exports =
     $
   ///
 
+  # https://developer.github.com/changes/2017-01-05-commit-search-api/
+  'application/vnd.github.inertia-preview+json': /// ^ (https?://[^/]+)? (/api/v3)?
+    (
+        /repos (/[^/]+){2} /projects
+      | /orgs/ ([^/]+) /projects
+      | /projects/ (
+          [0-9]+
+        | [0-9]+ /columns
+        | columns
+        | columns/ [0-9]+
+        | columns/ [0-9]+ /moves
+        | columns/ [0-9]+ /cards
+        | columns/cards/ [0-9]+
+        | columns/cards/ [0-9]+ /moves
+      )
+    )
+    $
+  ///
+
   # # https://developer.github.com/v3/oauth_authorizations/
   # 'application/vnd.github.mirage-preview+json': /// ^ (https?://[^/]+)? (/api/v3)?
   #   (

--- a/src/grammar/tree-options.js
+++ b/src/grammar/tree-options.js
@@ -65,6 +65,7 @@ const REPO_FIELDS = {
   'collaborators': {
     'permission': false
   },
+  'projects': false,
   'issues': {
     'events': false,
     'comments': false,
@@ -131,7 +132,16 @@ module.exports = {
     'issues': false,
     'members': false,
     'events': false,
+    'projects': false,
     'teams': false
+  },
+  'projects': {
+    'columns': {
+      'moves': false,
+      'cards': {
+        'moves': false
+      }
+    }
   },
   'teams': {
     'members': false,

--- a/src/grammar/url-validator.coffee
+++ b/src/grammar/url-validator.coffee
@@ -54,7 +54,16 @@ module.exports = /// ^
         | members
         | events
         | teams
+        | projects
       )
+
+    | projects/ [0-9]+
+    | projects/ [0-9]+ /columns
+    | projects/columns/ [0-9]+
+    | projects/columns/ [0-9]+ /moves
+    | projects/columns/ [0-9]+ /cards
+    | projects/columns/cards/ [0-9]+
+    | projects/columns/cards/ [0-9]+ /moves
 
     | teams/ [^/]+
     | teams/ [^/]+ / (
@@ -146,6 +155,7 @@ module.exports = /// ^
         | contents (/[^/]+)* # The path is allowed in the URL
         | collaborators (/[^/]+)?
         | collaborators / ([^/]+) / permission
+        | projects
         | (issues|pulls)
         | (issues|pulls) / (
               events


### PR DESCRIPTION
This adds support for the [Projects API](https://developer.github.com/v3/projects/) and fixes #144

Example (you must choose a repository that has the Projects enabled and you must be logged in):

```js
var Octo = require('./')
var octo = new Octo({token: process.env['GH_TOKEN']})

octo.repos('philschatz', 'gh-demo').projects.fetch()
.then((res) => {
  // console.log(res)
  return res.items[0].columns.fetch()
  .then((cols) => {
    // console.log(cols)
    return cols.items[0].cards.fetch()
    .then((cards) => {
      // console.log(cards)
      return cards.items[0].fetch()
      .then((card) => {
        console.log(card)
      })
    })
  })
})
```