### PR TITLE
Fix end event IDs when there are concurrent requests

### DIFF
--- a/src/requester.js
+++ b/src/requester.js
@@ -45,7 +45,7 @@ let ajax = function (options, cb) {
 // # Construct the request function.
 // It contains all the auth credentials passed in to the client constructor
 
-let eventId = 0 // counter for the emitter so it is easier to match up requests
+let EVENT_ID = 0 // counter for the emitter so it is easier to match up requests
 
 module.exports = class Requester {
   constructor (_instance, _clientOptions = {}, plugins) {
@@ -130,7 +130,7 @@ module.exports = class Requester {
         }
       }
 
-      eventId++
+      let eventId = ++EVENT_ID
       __guardFunc__(this._emit, f => f('start', eventId, {method, path, data, options}))
 
       return ajax(ajaxConfig, (err, val) => {

--- a/test/emitter.spec.js
+++ b/test/emitter.spec.js
@@ -2,7 +2,7 @@
 const { expect } = require('chai')
 const { Octokat, TOKEN, REPO_USER, REPO_NAME } = require('./test-config')
 
-describe('Event Emitter', () =>
+describe('Event Emitter', () => {
 
   it('emits when a request begins and when it completes', function (done) {
     let emittedStart = false
@@ -32,4 +32,24 @@ describe('Event Emitter', () =>
     // Mocha 3 does not like it when a promise is returned _and_ a done callback is expected
     return null
   })
-)
+
+  it('emits unique end event IDs that were also emitted in a start event', function (done) {
+    let ids = { start: [], end: [] }
+    let emitter = function (name, id) {
+      ids[name].push(id)
+      if (ids.end.length === 3) {
+        expect(ids.start[0]).to.not.equal(ids.start[1])
+        expect(ids.start[0]).to.not.equal(ids.start[2])
+        expect(ids.start[1]).to.not.equal(ids.start[2])
+        expect(ids.end).to.include(ids.start[0])
+        expect(ids.end).to.include(ids.start[1])
+        expect(ids.end).to.include(ids.start[2])
+        done()
+      }
+    }
+    let client = new Octokat({token: TOKEN, emitter})
+    client.repos(REPO_USER, REPO_NAME).fetch()
+    client.repos(REPO_USER, REPO_NAME).fetch()
+    client.repos(REPO_USER, REPO_NAME).fetch()
+  })
+})

--- a/test/emitter.spec.js
+++ b/test/emitter.spec.js
@@ -37,10 +37,16 @@ describe('Event Emitter', () => {
     let ids = { start: [], end: [] }
     let emitter = function (name, id) {
       ids[name].push(id)
+      if (name === 'end') {
+        // Make sure it previously appeared in a `start` event.
+        expect(ids.start).to.include(id)
+      }
       if (ids.end.length === 3) {
+        // Make sure each `start` ID is unique.
         expect(ids.start[0]).to.not.equal(ids.start[1])
         expect(ids.start[0]).to.not.equal(ids.start[2])
         expect(ids.start[1]).to.not.equal(ids.start[2])
+        // Make sure each ID from a `start` event also had an `end` event.
         expect(ids.end).to.include(ids.start[0])
         expect(ids.end).to.include(ids.start[1])
         expect(ids.end).to.include(ids.start[2])
@@ -48,6 +54,7 @@ describe('Event Emitter', () => {
       }
     }
     let client = new Octokat({token: TOKEN, emitter})
+    // Fire multiple concurrent requests to check their IDs
     client.repos(REPO_USER, REPO_NAME).fetch()
     client.repos(REPO_USER, REPO_NAME).fetch()
     client.repos(REPO_USER, REPO_NAME).fetch()


### PR DESCRIPTION
When there is an `end` event, it was being emitted with the current global `eventId` and not the ID that the request started with. This would result in `end` events with the same (and incorrect) ID when there are concurrent requests.

This makes sure to save the request's own ID after incrementing the global, and adds a test.