### PR TITLE
add support for /user/public_emails

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -88,6 +88,8 @@ gist.comments(COMMENT_ID).update({"body":":heart:"})
 ```coffee
 octo.user.repos.fetch()
 octo.user.starred('philschatz', 'octokat.js').add()
+octo.user.emails.fetch()
+octo.user.public_emails.fetch()
 
 octo.users.fetch()
 octo.users(USER).events.fetch()

--- a/src/grammar/tree-options.js
+++ b/src/grammar/tree-options.js
@@ -124,6 +124,7 @@ module.exports = {
     'following': false,
     'emails': false,
     'issues': false,
+    'public_emails': false,
     'starred': false,
     'teams': false
   },

--- a/src/grammar/url-validator.coffee
+++ b/src/grammar/url-validator.coffee
@@ -42,6 +42,7 @@ module.exports = /// ^
       | following (/[^/]+)?
       | emails    (/[^/]+)? # TODO: Are these additional args valid?
       | issues
+      | public_emails
       | starred
       | starred   (/[^/]+){2}
       | teams


### PR DESCRIPTION
This API was recently added: https://developer.github.com/v3/users/emails/#list-public-email-addresses-for-a-user

I used #155 as a reference to figure out how to add this - not sure if I've missed anything, or if you would like some extra test coverage.