### PR TITLE
Adding Install in its own section

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This package can be used in `nodejs` **or** in the browser as an AMD module or u
 
 # Table of Contents
 
+- [Install](#install)
 - [Key Features](#key-features)
 - [Overview](#overview)
 - [Examples](#examples)
@@ -40,6 +41,13 @@ This package can be used in `nodejs` **or** in the browser as an AMD module or u
   - [Using URLs Directly](#using-urls-directly)
   - [Development](#development)
 
+# Install
+
+Octokat uses [node](https://nodejs.org) and [npm](https://npmjs.com).
+
+```sh
+npm install --save octokat
+```
 
 # Key Features
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This package can be used in `nodejs` **or** in the browser as an AMD module or u
 
 # Install
 
-Octokat uses [node](https://nodejs.org) and [npm](https://npmjs.com).
+Octokat runs in [node](https://nodejs.org) or a browser and is available in [npm](https://npmjs.com/package/octokat).
 
 ```sh
 npm install --save octokat


### PR DESCRIPTION
After having a friend try to install this and getting stuck, I realize that there is no install section. Having it at the top makes running this a bit easier - otherwise, you have to search for install to learn the name of the repo. This should help onboarding new users, with minimal amount of space.