### PR TITLE
Adding repositories/id to URL_VALIDATOR

### DIFF
--- a/src/grammar/url-validator.coffee
+++ b/src/grammar/url-validator.coffee
@@ -28,7 +28,7 @@ module.exports = /// ^
     | rate_limit
     | feeds
     | events
-    | repositories
+    | repositories (/\d+)?
     | notifications
     | notifications / threads (/[^/]+)
     | notifications / threads (/[^/]+) / subscription


### PR DESCRIPTION
This is a nondocumented public way of getting a repository by ID.