### PR TITLE
Fix fetchAll typo

### DIFF
--- a/src/plugins/fetch-all.js
+++ b/src/plugins/fetch-all.js
@@ -23,7 +23,7 @@ let getMore = function (fetchable, requester, acc) {
 // TODO: HACK to handle camelCase and hypermedia plugins
 var fetchNextPage = function (obj, requester) {
   if (typeof obj.next_page_url === 'string') {
-    return requester.request('GET', obj.next_page, null, null)
+    return requester.request('GET', obj.next_page_url, null, null)
   } else if (obj.next_page) {
     return obj.next_page.fetch()
   } else if (typeof obj.nextPageUrl === 'string') {


### PR DESCRIPTION
I was trying to use the `fetchAll` plugin and it crashed with the following error

> Octokat Error: Calling fetchAll on a request that does not yield an array

I traced it down to the `fetchNextPage` function calling the requester with `undefined` instead of a URL and found this little typo. Worth noting is that this was in the [desktop/desktop](https://github.com/desktop/desktop) repo where we don't use the `camelCase` plugin. I suspect this might have worked just fine had we used the `camelCase` plugin.