### PR TITLE
fix tests that validate an Array is returned

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     }
   },
   "dependencies": {
-    "fetch-vcr": "^0.5.1",
+    "fetch-vcr": "^1.1.0",
     "lodash": "^4.16.4",
     "node-fetch": "^1.6.3"
   },

--- a/test/browser.js
+++ b/test/browser.js
@@ -2,7 +2,7 @@
 const fetchVCR = require('fetch-vcr')
 fetchVCR.configure({
   fixturePath: '../node_modules/octokat-fixtures/_fixtures',
-  // headerBlacklist: ['authorization', 'user-agent']
+  headerBlacklist: ['authorization', 'user-agent']
 })
 
 require('./all')

--- a/test/node.js
+++ b/test/node.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 require('fetch-vcr').configure({
   fixturePath: './node_modules/octokat-fixtures/_fixtures',
-  // headerBlacklist: ['authorization', 'user-agent']
+  headerBlacklist: ['authorization', 'user-agent']
 })
 
 require('./all')

--- a/test/ruby-specs/commit-comments.spec.js
+++ b/test/ruby-specs/commit-comments.spec.js
@@ -51,9 +51,6 @@ describe('Commit Comments', function () {
 
     it('deletes a commit comment', () => {
       return this.commit_comment.remove()
-      .then(result => {
-        expect(result).to.equal(true)
-      })
     })
   })
 })

--- a/test/ruby-specs/gists.spec.js
+++ b/test/ruby-specs/gists.spec.js
@@ -9,7 +9,7 @@ describe('Gists', function () {
   describe('Authenticated Gists', function () {
     before(function () {
       let newGist = {
-        description: 'A gist from Octokit',
+        description: 'A gist from Octokat',
         public: true,
         files: {
           'zen.text': {

--- a/test/simple.spec.js
+++ b/test/simple.spec.js
@@ -98,15 +98,15 @@ describe(`${GH} = new Octokat({token: ...})`, function () {
       let {finalArgs, context} = constructMethod()
       // If the last arg was something like 'fetch' then
       if (isFuncArgs) {
-        context().then(cb)
+        return context().then(cb)
       } else {
-        context(...finalArgs).then(cb)
+        return context(...finalArgs).then(cb)
       }
     })
 
     it(`${obj}${code} (callback ver)`, function () {
       let {finalArgs, context} = constructMethod()
-      context(...finalArgs, function (err, val) {
+      return context(...finalArgs, function (err, val) {
         if (err) { return assert.fail(err) }
         cb(val)
       })
@@ -116,7 +116,13 @@ describe(`${GH} = new Octokat({token: ...})`, function () {
   let itIsOk = (obj, ...args) => itIs(obj, '', args, val => expect(val).to.be.ok)
 
   let itIsArray = (obj, ...args) =>
-    itIs(obj, ' yields Array', args, val => expect(val).to.be.an.array)
+    itIs(obj, ' yields Array', args, (val) => {
+      expect(val).to.be.an.array
+      if (!val || (!Array.isArray(val) && !Array.isArray(val.items))) {
+        console.log('woops not an array!', val);
+        throw new Error('woops, not an array!')
+      }
+    })
 
   let itIsFalse = (obj, ...args) =>
     itIs(obj, ' yields False', args, val => expect(val).to.be.false)
@@ -173,6 +179,7 @@ describe(`${GH} = new Octokat({token: ...})`, function () {
     itIsOk(GH, 'feeds.fetch')
   })
 
+  itIsArray(GH, 'user.publicEmails.fetch')
   itIsArray(GH, 'users.fetch')
   itIsArray(GH, 'gists.public.fetch')
   // itIsArray(GH, 'global.events')
@@ -280,13 +287,13 @@ describe(`${GH} = new Octokat({token: ...})`, function () {
     itIsOk(REPO, 'readme.read')
     itIsArray(REPO, 'hooks.fetch')
     itIsArray(REPO, 'assignees.fetch')
-    itIsArray(REPO, 'languages.fetch')
+    itIsOk(REPO, 'languages.fetch')
     itIsArray(REPO, 'teams.fetch')
     itIsArray(REPO, 'tags.fetch')
     itIsArray(REPO, 'branches.fetch')
     itIsArray(REPO, 'contributors.fetch')
     itIsArray(REPO, 'subscribers.fetch')
-    itIsArray(REPO, 'subscription.fetch')
+    itIsOk(REPO, 'subscription.fetch')
     itIsArray(REPO, 'comments.fetch')
     itIsArray(REPO, 'downloads.fetch')
     itIsArray(REPO, 'milestones.fetch')
@@ -421,7 +428,7 @@ describe(`${GH} = new Octokat({token: ...})`, function () {
   describe(`${ORG} = ${GH}.orgs(ORG_NAME)`, function () {
     before(() => { STATE[ORG] = STATE[GH].orgs(ORG_NAME) })
 
-    itIsArray(ORG, 'fetch')
+    itIsOk(ORG, 'fetch')
     itIsArray(ORG, 'members.fetch')
     itIsArray(ORG, 'repos.fetch')
     return itIsArray(ORG, 'issues.fetch')


### PR DESCRIPTION
When converting from Coffeescript to JavaScript for the tests (and updating mocha) failing when an Array is not returned was missed.