### PR TITLE
Add GitHub Enterprise setting as env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,9 +389,11 @@ To use the Enterprise APIs add the root URL when instantiating Octokat:
 ```js
 var octo = new Octokat({
   token: 'API_TOKEN',
-  rootURL: 'https://example.com/api/v3'
+  githubEndpoint: 'https://example.com/api/v3'
 })
 ```
+
+You can also set the githubEndpoint as an environmental token called `GITHUB_ENDPOINT`.
 
 ## Using EcmaScript 6 Generators
 

--- a/dist/octokat.js
+++ b/dist/octokat.js
@@ -1937,8 +1937,8 @@ module.exports = function () {
     // Provide an option to override the default URL
     this._instance = _instance;
     this._clientOptions = _clientOptions;
-    if (this._clientOptions.rootURL == null) {
-      this._clientOptions.rootURL = 'https://api.github.com';
+    if (this._clientOptions.githubEndpoint == null) {
+      this._clientOptions.githubEndpoint = 'https://api.github.com';
     }
     if (this._clientOptions.useETags == null) {
       this._clientOptions.useETags = true;
@@ -2004,7 +2004,7 @@ module.exports = function () {
       // Only prefix the path when it does not begin with http.
       // This is so pagination works (which provides absolute URLs).
       if (!/^http/.test(path)) {
-        path = '' + this._clientOptions.rootURL + path;
+        path = '' + this._clientOptions.githubEndpoint + path;
       }
 
       var headers = {

--- a/src/requester.js
+++ b/src/requester.js
@@ -16,7 +16,7 @@ module.exports = class Requester {
     // Provide an option to override the default URL
     this._instance = _instance
     this._clientOptions = _clientOptions
-    if (this._clientOptions.rootURL == null) { this._clientOptions.rootURL = 'https://api.github.com' }
+    if (this._clientOptions.githubEndpoint == null) { this._clientOptions.githubEndpoint = process.env.GITHUB_ENDPOINT || 'https://api.github.com' }
     if (this._clientOptions.useETags == null) { this._clientOptions.useETags = true }
     if (this._clientOptions.usePostInsteadOfPatch == null) { this._clientOptions.usePostInsteadOfPatch = false }
     if (this._clientOptions.userAgent == null) {
@@ -53,7 +53,7 @@ module.exports = class Requester {
 
     // Only prefix the path when it does not begin with http.
     // This is so pagination works (which provides absolute URLs).
-    if (!/^http/.test(path)) { path = `${this._clientOptions.rootURL}${path}` }
+    if (!/^http/.test(path)) { path = `${this._clientOptions.githubEndpoint}${path}` }
 
     let headers = {
       'Accept': this._clientOptions.acceptHeader || 'application/json',


### PR DESCRIPTION
Here, I add process.env.GITHUB_ENDPOINT as a possible environmental var
to use to change the rootURL. I change all instances of `rootURL` to
`githubEndpoint`, as that is the token used in [`gh-got`](https://github.com/sindresorhus/gh-got)
and it seemed like a good idea to just copy that token.

I was unsure of how to add a test for this.