### PR TITLE
Added support for organizations urls

### DIFF
--- a/src/grammar/url-validator.coffee
+++ b/src/grammar/url-validator.coffee
@@ -19,7 +19,6 @@ module.exports = /// ^
       zen
     | octocat
     | users
-    | organizations
     | issues
     | gists
     | emojis
@@ -48,8 +47,8 @@ module.exports = /// ^
       | teams
     )
 
-    | orgs/  [^/]+
-    | orgs/  [^/]+ / (
+    | (orgs/  [^/]+) | ((organizations)(/ \d+)? )
+    | (orgs/  [^/]+) | ( organizations/ \d+) / (
           repos
         | issues
         | members


### PR DESCRIPTION
ref #202  (link header returns urls with /organizations/12345/repos?page=2 and similar)

Organizations url require an numeric id
https://api.github.com/organizations/1089146

Does not work:
https://api.github.com/organizations/atom
vs 
https://api.github.com/orgs/atom

The new regexp matches should match all of the following (and more):

- https://api.github.com/organizations
- https://api.github.com/orgs/atom
- https://api.github.com/organizations/1089146
- https://api.github.com/organizations/1089146/repos

etc
