### PR TITLE
Allow access to `repo.git.tags`

### DIFF
--- a/src/grammar/tree-options.js
+++ b/src/grammar/tree-options.js
@@ -78,7 +78,8 @@ const REPO_FIELDS = {
     },
     'trees': false,
     'blobs': false,
-    'commits': false
+    'commits': false,
+    'tags': false
   },
   'stats': {
     'contributors': false,

--- a/src/grammar/url-validator.coffee
+++ b/src/grammar/url-validator.coffee
@@ -188,6 +188,7 @@ module.exports = /// ^
             | trees (/[^/]+)? # Can be a sha or a branch name
             | blobs (/[a-f0-9]{40}$)?
             | commits (/[a-f0-9]{40}$)?
+            | tags (/[^/]+)?
           )
         | stats/ (
               contributors


### PR DESCRIPTION
Github's `/git/refs/tag/<TAG>` endpoint seems to be limited to annotated tags. I encountered a situation where I needed to access a lightweight tag that, itself, pointed to an annotated release tag. When fetching this ref, the `object.url` returned by Github was of the form `/git/tags/<TAG>` but this form was not supported by Octokat. These changes allow the fetching of lightweight tags through `repo.git.tags`.

[This SO answer](https://stackoverflow.com/a/29199717/682618) was pivotal in helping me understand this case and identify the solution.